### PR TITLE
create test-jar for developers who want to write CodeNarc rule tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,19 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 


### PR DESCRIPTION
This will make it possible for people to write tests for their project specific custom rules. Ideally the test jar will be pushed out to Maven central with the main jar, perhaps even for that last stable release (since I don't see much activity).
Alternatively AbstractRuleTestCase and any other testing dependencies could be moved to source. It would be nice to have access to this ASAP as now we have the capability of writing custom rules, without the use of your test infrastructure since it is not in the jar. We are forced to either write rules with no tests, alternate test infrastructure, or hack the build and make our own test jar.

In case you don't see the value of project specific rules:
- Rule authors have to practice somewhere before coming up with great generally useful rules.
- CodeNarc is actually positioned well as a platform for creating rules, rather than just a library of them. Groovy is lacking in static analysis tools compared to Java. People are counting on CodeNarc to fill a lot of gaps.
- People can already write project specific rules, just not tests. So the cat is out of the bag in a dangerous way.
