### PR TITLE
Fix #3558623: UnnecessarySemicolon - violations inside classes were ignored

### DIFF
--- a/src/main/groovy/org/codenarc/rule/dry/DryUtil.groovy
+++ b/src/main/groovy/org/codenarc/rule/dry/DryUtil.groovy
@@ -127,10 +127,10 @@ class DryUtil {
             return false
         }
 
-        Expression object1 = ((PropertyExpression) expression1).getObjectExpression();
-        Expression property1 = ((PropertyExpression) expression1).getProperty();
-        Expression object2 = ((PropertyExpression) expression2).getObjectExpression();
-        Expression property2 = ((PropertyExpression) expression2).getProperty();
+        Expression object1 = ((PropertyExpression) expression1).getObjectExpression()
+        Expression property1 = ((PropertyExpression) expression1).getProperty()
+        Expression object2 = ((PropertyExpression) expression2).getObjectExpression()
+        Expression property2 = ((PropertyExpression) expression2).getProperty()
 
         boolean isTheSame = false
 

--- a/src/main/groovy/org/codenarc/rule/unnecessary/UnnecessarySemicolonRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/unnecessary/UnnecessarySemicolonRule.groovy
@@ -15,8 +15,6 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codehaus.groovy.ast.ClassNode
-import org.codehaus.groovy.ast.MethodNode
 import org.codehaus.groovy.ast.expr.ConstantExpression
 import org.codenarc.rule.AbstractAstVisitor
 import org.codenarc.rule.AbstractAstVisitorRule
@@ -47,7 +45,7 @@ class UnnecessarySemicolonRule extends AbstractAstVisitorRule {
         protected Object initialValue() {
             []
         }
-    };
+    }
 
     @Override
     void applyTo(SourceCode sourceCode, List violations) {
@@ -86,23 +84,6 @@ class UnnecessarySemicolonRule extends AbstractAstVisitorRule {
 }
 
 class UnnecessarySemicolonAstVisitor extends AbstractAstVisitor {
-    boolean ignoreViolations = false
-
-    @Override
-    protected void visitClassEx(ClassNode node) {
-
-        if (!ignoreViolations) {
-            removeViolationsInRange(node.lineNumber, node.lastLineNumber)
-        } 
-    }
-
-    @Override
-    void visitMethodEx(MethodNode node) {
-        if (!ignoreViolations) {
-            removeViolationsInRange(node.lineNumber, node.lastLineNumber)
-        } 
-    }
-
     @Override
     void visitConstantExpression(ConstantExpression node) {
 

--- a/src/main/groovy/org/codenarc/source/AbstractSourceCode.groovy
+++ b/src/main/groovy/org/codenarc/source/AbstractSourceCode.groovy
@@ -50,7 +50,7 @@ abstract class AbstractSourceCode implements SourceCode {
      * @param suppressionAnalyzer suppression analyzer
      */
     protected void setSuppressionAnalyzer(SuppressionAnalyzer suppressionAnalyzer) {
-        this.suppressionAnalyzer = suppressionAnalyzer;
+        this.suppressionAnalyzer = suppressionAnalyzer
     }
 
     /**
@@ -58,9 +58,9 @@ abstract class AbstractSourceCode implements SourceCode {
      */
     List getLines() {
         if (lines == null) {
-            lines = new StringReader(getText()).readLines();
+            lines = new StringReader(getText()).readLines()
         }
-        return lines;
+        return lines
     }
 
     /**

--- a/src/test/groovy/org/codenarc/analyzer/SuppressionAnalyzerTest.groovy
+++ b/src/test/groovy/org/codenarc/analyzer/SuppressionAnalyzerTest.groovy
@@ -277,7 +277,7 @@ class SuppressionAnalyzerTest extends GroovyTestCase {
 
         @Override
         List applyTo(SourceCode sourceCode) {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException()
         }
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessarySemicolonRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessarySemicolonRuleTest.groovy
@@ -30,7 +30,6 @@ class UnnecessarySemicolonRuleTest extends AbstractRuleTestCase {
         assert rule.name == 'UnnecessarySemicolon'
     }
 
-    @SuppressWarnings('UnnecessarySemicolon')
     void testSuccessScenario() {
         final SOURCE = '''
 /*
@@ -56,8 +55,13 @@ class UnnecessarySemicolonRuleTest extends AbstractRuleTestCase {
                 ;
             }
 
+            @SuppressWarnings('UnnecessarySemicolon')
+            class A {
+                String a = 'text';
+            }
+
         '''
-        assertNoViolations(SOURCE)
+        assert !manuallyApplyRule(SOURCE)
     }
 
     void testSimpleString() {
@@ -89,7 +93,6 @@ class UnnecessarySemicolonRuleTest extends AbstractRuleTestCase {
         assertSingleViolation SOURCE, 7, '            """;'
     }
 
-    @SuppressWarnings('UnnecessarySemicolon')
     void testPackage() {
         final SOURCE = '''
             package my.company.server;
@@ -97,7 +100,6 @@ class UnnecessarySemicolonRuleTest extends AbstractRuleTestCase {
         assertSingleViolation(SOURCE, 2, 'package my.company.server;', 'Semi-colons as line endings can be removed safely')
     }
 
-    @SuppressWarnings('UnnecessarySemicolon')
     void testLoop() {
         final SOURCE = '''
             for (def x : list);
@@ -105,7 +107,6 @@ class UnnecessarySemicolonRuleTest extends AbstractRuleTestCase {
         assertSingleViolation(SOURCE, 2, 'for (def x : list);', 'Semi-colons as line endings can be removed safely')
     }
 
-    @SuppressWarnings('UnnecessarySemicolon')
     void testMethodCall() {
         final SOURCE = '''
             println(value) ;
@@ -119,6 +120,17 @@ class UnnecessarySemicolonRuleTest extends AbstractRuleTestCase {
             import java.lang.String;    
         '''
         assertSingleViolation(SOURCE, 2, 'import java.lang.String;', 'Semi-colons as line endings can be removed safely')
+    }
+
+    void testClass() {
+        final SOURCE = '''
+            class A {
+                int a() {
+                    return 1;
+                }
+            }
+        '''
+        assertSingleViolation(SOURCE, 4, 'return 1;', 'Semi-colons as line endings can be removed safely')
     }
 
     protected Rule createRule() {


### PR DESCRIPTION
This pull request contains:
- a fix for a bug where violations of UnnecessarySemicolonRule where completely ignored for class bodies
- UnnecessarySemicolonAstVisitor and UnnecessarySemicolonRuleTest cleanups
- fixes for quite some previously undetected UnnecessarySemicolonRule violations in Codenarc's code base
