### PR TITLE
parseReport doesn't work with absolute paths on windows

### DIFF
--- a/src/main/groovy/org/codenarc/CodeNarc.groovy
+++ b/src/main/groovy/org/codenarc/CodeNarc.groovy
@@ -166,7 +166,7 @@ Usage: java org.codenarc.CodeNarc [OPTIONS]
     }
 
     private parseReport(String argValue) {
-        def parts = argValue.tokenize(':')
+        def parts = argValue.split(':', 2)
         def type = parts[0]
         def reportWriter = new ReportWriterFactory().getReportWriter(type)
 


### PR DESCRIPTION
Windows absolute paths can contain colons and tokenizing on : was
breaking them, e.g. xml:c:/whatever was being tokenized to
[xml,c,/whatever] rather than split into [xml,c:/whatever].

Btw - new to github so if I messed this up it wouldn't surprise me.

gavin
