### PR TITLE
Enhanced UnusedVariableRule to ignore some variables

### DIFF
--- a/src/main/groovy/org/codenarc/rule/unused/UnusedVariableRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/unused/UnusedVariableRule.groovy
@@ -26,6 +26,7 @@ import org.codenarc.rule.AbstractAstVisitor
 import org.codenarc.rule.AbstractAstVisitorRule
 import org.codenarc.source.SourceCode
 import org.codenarc.util.AstUtil
+import org.codenarc.util.WildcardPattern
 
 /**
  * Rule that checks for variables that are not referenced.
@@ -36,6 +37,7 @@ import org.codenarc.util.AstUtil
 class UnusedVariableRule extends AbstractAstVisitorRule {
     String name = 'UnusedVariable'
     int priority = 2
+    String ignoreVariableNames
 
     @Override
     void applyTo(SourceCode sourceCode, List violations) {
@@ -94,7 +96,7 @@ class UnusedVariableAstVisitor extends AbstractAstVisitor  {
         super.visitBlockStatement(block)
 
         variablesInCurrentBlockScope.each { varExpression, isUsed ->
-            if (!isUsed && !anonymousReferences.contains(varExpression.name)) {
+            if (!isIgnoredVariable(varExpression) && !isUsed && !anonymousReferences.contains(varExpression.name)) {
                 addViolation(varExpression, "The variable [${varExpression.name}] in class $currentClassName is not used")
             }
         }
@@ -132,5 +134,9 @@ class UnusedVariableAstVisitor extends AbstractAstVisitor  {
                 }
             }
         }
+    }
+
+    private boolean isIgnoredVariable(VariableExpression expression) {
+        new WildcardPattern(rule.ignoreVariableNames, false).matches(expression.name)
     }
 }

--- a/src/main/resources/codenarc-base-messages.properties
+++ b/src/main/resources/codenarc-base-messages.properties
@@ -836,8 +836,8 @@ UnusedPrivateMethod.description.html=Checks for private methods that are not ref
 UnusedPrivateMethodParameter.description=Checks for parameters to private methods that are not referenced within the method body.
 UnusedPrivateMethodParameter.description.html=Checks for parameters to private methods that are not referenced within the method body.
 
-UnusedVariable.description=Checks for variables that are never referenced.
-UnusedVariable.description.html=Checks for variables that are never referenced.
+UnusedVariable.description=Checks for variables that are never referenced. The ignoreVariableNames property (${rule.ignoreVariableNames}) specifies one or more variable names that should be ignored, optionally containing wildcard characters ('*' or '?').
+UnusedVariable.description.html=Checks for variables that are never referenced. The <em>ignoreVariableNames</em> property (${rule.ignoreVariableNames}) specifies one or more variable names that should be ignored, optionally containing wildcard characters ('*' or '?').
 
 WaitOutsideOfWhileLoop.description=Calls to Object.wait() must be within a while loop. Consider using the Java concurrency utilities instead of wait() and notify().
 WaitOutsideOfWhileLoop.description.html=Calls to <em>Object.wait()</em> must be within a <em>while</em> loop. Consider using the Java concurrency utilities instead of <em>wait()</em> and <em>notify()</em>.

--- a/src/site/apt/codenarc-rules-unused.apt
+++ b/src/site/apt/codenarc-rules-unused.apt
@@ -189,6 +189,17 @@ Unused Rules  ("<rulesets/unused.xml>")
 
   Checks for variables that are never referenced.
 
+  The rule has a property named ignoreVariableNames, which can be set to ignore some variable names.
+  For instance, to ignore fields named 'unused', set the property to 'unused'.
+
+*---------------------+----------------------------------------------------------------+------------------------+
+| <<Property>>        | <<Description>>                                                | <<Default Value>>      |
+*---------------------+----------------------------------------------------------------+------------------------+
+| ignoreVariableNames | Specifies one or more (comma-separated) variable names that    | <<<null>>>             |
+|                     | should be ignored (i.e., that should not cause a rule          |                        |
+|                     | violation). The names may optionally contain wildcards (*,?).  |                        |
+*---------------------+----------------------------------------------------------------+------------------------+
+
   Known limitations:
 
   * Incorrectly considers a variable referenced if another variable with the same name is referenced

--- a/src/test/groovy/org/codenarc/rule/unused/UnusedVariableRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unused/UnusedVariableRuleTest.groovy
@@ -330,6 +330,48 @@ class UnusedVariableRuleTest extends AbstractRuleTestCase {
         assertNoViolations(SOURCE)
     }
 
+    @Test
+    void testApplyTo_IgnoreVariableNames_MatchesSingleName() {
+        final SOURCE = '''
+            class MyClass {
+                def myMethod() {
+                    BigDecimal depositAmount
+                }
+            }
+        '''
+        rule.ignoreVariableNames = 'depositAmount'
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testApplyTo_IgnoreVariableNames_MatchNoNames() {
+        final SOURCE = '''
+            class MyClass {
+                def myMethod() {
+                    BigDecimal depositAmount
+                }
+            }
+        '''
+        rule.ignoreVariableNames = 'other'
+        assertSingleViolation(SOURCE, 4, 'BigDecimal depositAmount', 'The variable [depositAmount] in class MyClass is not used')
+    }
+
+    @Test
+    void testApplyTo_IgnoreVariableNames_MultipleNamesWithWildcards() {
+        final SOURCE = '''
+            class MyClass {
+                def myMethod() {
+                    BigDecimal depositAmount
+                    def other
+                    int count
+                    long otherMax
+                }
+            }
+        '''
+        rule.ignoreVariableNames = 'oth*,xxx,deposit??ount'
+        assertSingleViolation(SOURCE, 6, 'int count', 'The variable [count] in class MyClass is not used')
+    }
+
     protected Rule createRule() {
         new UnusedVariableRule()
     }


### PR DESCRIPTION
The rule can now be configured via 'ignoreVariableNames'.
This is especially usefull for multi-variable-assignments:

def (var1, _, var2, _, _, var3) = someMethod()
