### PR TITLE
Codenarc can use emptyString for DuplicateStringLiteralRule in config

### DIFF
--- a/src/main/groovy/org/codenarc/rule/dry/DuplicateStringLiteralRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/dry/DuplicateStringLiteralRule.groovy
@@ -46,7 +46,7 @@ class DuplicateStringLiteralRule extends AbstractAstVisitorRule {
         if (ignoreStrings == null) {
             return Collections.EMPTY_SET
         }
-        def strings = ignoreStrings.contains(',') ? ignoreStrings.tokenize(',') : [ignoreStrings]
+        def strings = ignoreStrings.contains(',') ? ignoreStrings.split(',') : [ignoreStrings]
         strings as Set
     }
 }

--- a/src/test/groovy/org/codenarc/rule/dry/DuplicateStringLiteralRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/dry/DuplicateStringLiteralRuleTest.groovy
@@ -211,6 +211,18 @@ class DuplicateStringLiteralRuleTest extends AbstractRuleTestCase {
     }
 
     @Test
+    void testIgnoreStrings_IgnoresMultipleValuesWithEmptyString() {
+        final SOURCE = '''
+        	def x = ['xyz', 'abc', 'xyz']
+            def y = ['foo', 'bar', 'foo']
+            def z = ['', 'efg', '']
+        '''
+
+        rule.ignoreStrings = ',xyz,foo'
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
     void testIgnoreValues_IgnoresValuesSurroundedByWhitespace() {
         final SOURCE = '''
         	def x = [' xyz ', 'abc', ' xyz ']


### PR DESCRIPTION
I will use empty string for DuplicateStringLiteralRule with multiple value in config.
But, String#tokenize ignore empty string.
I use String#split as String#tokenize.
