### PR TITLE
Pass the current ClassLoader to the GroovyShell.

### DIFF
--- a/src/main/groovy/org/codenarc/ruleset/GroovyDslRuleSet.groovy
+++ b/src/main/groovy/org/codenarc/ruleset/GroovyDslRuleSet.groovy
@@ -55,7 +55,7 @@ class GroovyDslRuleSet implements RuleSet {
         }
         Binding binding = new Binding(ruleset:callRuleSet)
 
-        return new GroovyShell(binding)
+        return new GroovyShell(this.class.classLoader, binding)
     }
 
     private void evaluateDsl(GroovyShell shell) {


### PR DESCRIPTION
Currently the GroovyShell that is constructed for parsing the Groovy DSL
syntax cannot find additional classes that have been added to the
CodeNarc classpath during execution. This change sets the ClassLoader on
the GroovyShell to be that of the executing tasks so that all classes on
the classpath are available when the DSL is parsed. This issue exhibits
itself when a rule DSL file looks like this:

```
import com.mycompany.rules.MyCustomRule
ruleset {
  rule(MyCustomRule)
}
```

This issue was discovered using the Gradle Codenarc plugin and trying
to add custom rules to the Codenarc execution:

```
dependencies {
   codenarc project(':codenarcrules')
}
```

Debugging showed that at GroovyDSLRuleSet:58, the MyCusotmRule class was
available and new instances could be created but the GroovyShell
couldn't find it.
