### PR TITLE
Fixes #25 - MissingMethodException error on custom rule with recent Groovy

### DIFF
--- a/src/main/groovy/org/codenarc/ruleset/RuleSetUtil.groovy
+++ b/src/main/groovy/org/codenarc/ruleset/RuleSetUtil.groovy
@@ -44,7 +44,7 @@ class RuleSetUtil {
         Class ruleClass
         inputStream.withStream { input ->
             GroovyClassLoader gcl = new GroovyClassLoader(getClass().classLoader)
-            ruleClass = gcl.parseClass(input)
+            ruleClass = gcl.parseClass(input.text)
         }
         assertClassImplementsRuleInterface(ruleClass)
         ruleClass.newInstance()


### PR DESCRIPTION
Without the need to upgrade the Groovy dependency of CodeNarc, this change uses a method signature `GroovyClassLoader.parseClass(String)` which exists in later Groovy versions. This allows custom rules to be read and used by the codenarc grails plugin in recent Grails versions that use recent Groovy versions. Tested with this Grails project: https://github.com/Netflix/asgard

All CodeNarc unit tests still pass.
