### PR TITLE
CloseWithoutCloseableRule: support indirect implementation of Closeable

### DIFF
--- a/src/main/groovy/org/codenarc/rule/design/CloseWithoutCloseableRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/design/CloseWithoutCloseableRule.groovy
@@ -16,6 +16,7 @@
 package org.codenarc.rule.design
 
 import org.codehaus.groovy.ast.MethodNode
+import org.codehaus.groovy.control.Phases
 import org.codenarc.rule.AbstractAstVisitorRule
 import org.codenarc.rule.AbstractMethodVisitor
 import org.codenarc.util.AstUtil
@@ -31,6 +32,7 @@ class CloseWithoutCloseableRule extends AbstractAstVisitorRule {
     String name = 'CloseWithoutCloseable'
     int priority = 2
     Class astVisitorClass = CloseWithoutCloseableAstVisitor
+    int compilerPhase = Phases.SEMANTIC_ANALYSIS
 }
 
 class CloseWithoutCloseableAstVisitor extends AbstractMethodVisitor {

--- a/src/test/groovy/org/codenarc/rule/design/CloseWithoutCloseableRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/CloseWithoutCloseableRuleTest.groovy
@@ -54,6 +54,21 @@ class CloseWithoutCloseableRuleTest extends AbstractRuleTestCase {
     }
 
     @Test
+    void testCloseWith_IndirectlyImplementedCloseable_NoViolations() {
+        final SOURCE = '''
+            class InputStreamsAreCloseable extends InputStream { // through class
+                void close() {}
+            }
+
+            class ChannelsAreCloseable implements java.nio.channels.Channel { // through interface
+                void close() {}
+                boolean isOpen() { false }
+            }
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
     void testPublicCloseViolation() {
         final SOURCE = '''
             class MyClass {


### PR DESCRIPTION
Prior to this, the rule would fail if a class included a close method while either
extending a class that implements Closeable, or implementing an interface
that extends Closeable, either of which is a false positive.  The fix is to
use a slightly later compilerPhase, similar to CloneWithoutCloneableRule.
A new test method is included to provide test coverage for this case.
