### PR TITLE
Extended UnusedImportRule to detect more unused imports

### DIFF
--- a/src/main/groovy/org/codenarc/rule/imports/UnusedImportRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/imports/UnusedImportRule.groovy
@@ -63,9 +63,9 @@ class UnusedImportRule extends AbstractRule {
         def aliasSameAsNonQualifiedClassName = className && className.endsWith(alias)
         sourceCode.lines.find { line ->
             if (!isImportStatementForAlias(line, alias)) {
-                def aliasCount = line.count(alias)
+                def aliasCount = countUsage(line, alias)
                 return aliasSameAsNonQualifiedClassName ?
-                    aliasCount && aliasCount > line.count(className) : aliasCount
+                    aliasCount && aliasCount > countUsage(line, className) : aliasCount
             }
         }
     }
@@ -73,5 +73,9 @@ class UnusedImportRule extends AbstractRule {
     private isImportStatementForAlias(String line, String alias) {
         final IMPORT_PATTERN = /import\s+.*/ + alias
         line =~ IMPORT_PATTERN
+    }
+
+    private countUsage(String line, String pattern) {
+        (line =~ /\b${pattern}\b/).count
     }
 }

--- a/src/main/groovy/org/codenarc/rule/naming/ConfusingMethodNameRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/naming/ConfusingMethodNameRule.groovy
@@ -21,7 +21,6 @@ import org.codehaus.groovy.ast.MethodNode
 import org.codehaus.groovy.ast.Parameter
 import org.codenarc.rule.AbstractAstVisitor
 import org.codenarc.rule.AbstractAstVisitorRule
-import org.codenarc.rule.Rule
 import org.codenarc.util.AstUtil
 
 /**

--- a/src/test/groovy/org/codenarc/rule/imports/UnusedImportRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/imports/UnusedImportRuleTest.groovy
@@ -121,6 +121,17 @@ class UnusedImportRuleTest extends AbstractRuleTestCase {
     }
 
     @Test
+    void testApplyTo_UnusedImport_SubstringOccurrence() {
+        final SOURCE = '''
+            import com.example.Service
+            class ABC {
+                def getService() { }
+            }
+        '''
+        assertSingleViolation(SOURCE, 2, 'import com.example.Service', 'The [com.example.Service] import is never referenced')
+    }
+
+    @Test
     void testApplyTo_UnusedImportWildcard() {
         final SOURCE = '''
             import org.codenarc.*


### PR DESCRIPTION
Now also detects cases where the imported class name occurs as a substring in the source code.
