### PR TITLE
Flags to ignore import and package line length

### DIFF
--- a/src/main/groovy/org/codenarc/rule/formatting/LineLengthRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/LineLengthRule.groovy
@@ -30,6 +30,8 @@ class LineLengthRule extends AbstractAstVisitorRule {
     String name = 'LineLength'
     int priority = 2
     int length = 120 // The default max line length. Can be overridden
+    boolean ignoreImportStatements = true // import statements can be longer than the max line legnth
+    boolean ignorePackageStatements = true // import statements can be longer than the max line legnth
 
     @Override
     void applyTo(SourceCode sourceCode, List violations) {
@@ -37,10 +39,37 @@ class LineLengthRule extends AbstractAstVisitorRule {
         int lineNumber = 0
         for (line in sourceCode.getLines()) {
             lineNumber++
-            if (line.length() > length) {
+            if (sourceViolatesLineLengthRule(line)) {
                 violations << createViolation(lineNumber, line, "The line exceeds $length characters. The line is ${line.length()} characters.")
             }
         }
     }
-}
 
+    private Boolean sourceViolatesLineLengthRule(String line) {
+        lineExceedsMaxLength(line) && (flagIfImport(line) || flagIfPackage(line) || flagIfRegularLine(line))
+    }
+
+    private Boolean flagIfImport(String line) {
+        (sourceLineIsImport(line) && !ignoreImportStatements)
+    }
+
+    private Boolean flagIfPackage(String line) {
+        (sourceLineIsPackage(line) && !ignorePackageStatements)
+    }
+
+    private Boolean flagIfRegularLine(String line) {
+        !sourceLineIsImport(line) && !sourceLineIsPackage(line)
+    }
+
+    private Boolean sourceLineIsImport(String line) {
+        line.trim().startsWith('import ')
+    }
+
+    private Boolean sourceLineIsPackage(String line) {
+        line.trim().startsWith('package ')
+    }
+
+    private Boolean lineExceedsMaxLength(String line) {
+        line.length() > length
+    }
+}

--- a/src/test/groovy/org/codenarc/rule/formatting/LineLengthRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/LineLengthRuleTest.groovy
@@ -31,6 +31,7 @@ class LineLengthRuleTest extends AbstractRuleTestCase {
     void testRuleProperties() {
         assert rule.priority == 2
         assert rule.name == 'LineLength'
+        assert rule.ignoreImportStatements
     }
 
     @Test
@@ -54,6 +55,58 @@ class LineLengthRuleTest extends AbstractRuleTestCase {
         '''
         assertSingleViolation(SOURCE, 3, 'def longMethod123456789012345678900123456789012345678901234567890123456789012345678901234567890123456',
                 'The line exceeds 120 characters. The line is 121 characters.')
+    }
+
+    @Test
+    void testIgnoresImportStatements() {
+        final SOURCE = '''
+            import longMethod123456789012345678900123456789012345678901234567890123456789012345678901234567890123456423452435asdfasdfadsfasdfasdfasdfadfasdfasdfadfasdfasdfadsf
+        	class Person {
+                def longMethodButNotQuiteLongEnough1234567890123456789012345() {
+                }
+            }
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testDoesNotIgnoreImportStatementsWhenFlagDisabled() {
+        rule.ignoreImportStatements = false
+
+        final SOURCE = '''
+            import longMethod123456789012345678900123456789012345678901234567890123456789012345678901234567890123456423452435asdfasdfadsfasdfasdfasdfadfasdfasdfadfasdfasdfadsf
+        	class Person {
+                def longMethodButNotQuiteLongEnough1234567890123456789012345() {
+                }
+            }
+        '''
+        assertSingleViolation(SOURCE, 2, 'import longMethod123456789012345678900123456789012345678901234567890123456789012345678901234567890123456423452435asdfasdfadsfasdfasdfasdfadfasdfasdfadfasdfasdfadsf')
+    }
+
+    @Test
+    void testIgnoresPackageStatements() {
+        final SOURCE = '''
+            package longMethod123456789012345678900123456789012345678901234567890123456789012345678901234567890123456423452435asdfasdfadsfasdfasdfasdfadfasdfasdfadfasdfasdfadsf
+        	class Person {
+                def longMethodButNotQuiteLongEnough1234567890123456789012345() {
+                }
+            }
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testDoesNotIgnorePackageStatementsWhenFlagDisabled() {
+        rule.ignorePackageStatements = false
+
+        final SOURCE = '''
+            package longMethod123456789012345678900123456789012345678901234567890123456789012345678901234567890123456423452435asdfasdfadsfasdfasdfasdfadfasdfasdfadfasdfasdfadsf
+        	class Person {
+                def longMethodButNotQuiteLongEnough1234567890123456789012345() {
+                }
+            }
+        '''
+        assertSingleViolation(SOURCE, 2, 'package longMethod123456789012345678900123456789012345678901234567890123456789012345678901234567890123456423452435asdfasdfadsfasdfasdfasdfadfasdfasdfadfasdfasdfadsf')
     }
 
     @Test


### PR DESCRIPTION
The Google Java Style guide says that package and import statements
should always be on a single line even if it is over the maximum (80 or
100) character line length. This seems like a good rule to follow for
groovy too.

I added an ignorePackageStatement and ignoreImportStatement options to
the LengthLengthRule. Both default to true.
