### PR TITLE
Added a No Wild Card imports rule.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,3 @@
-
 CodeNarc Change Log
 -------------------------------------------------------------------------------
 http://www.codenarc.org
@@ -7,6 +6,8 @@ Changes in version 0.21 (??? 2014)
 -------------------------------------------
 NEW RULES
 - #30: GrailsMassAssignment rule (grails) - Checks for mass assignment from a params Map within Grails domain classes. (Thanks to Brian Soby)
+- NoWildCardImports rule (imports) - Wildcard imports, static or otherwise, are not used.
+
 
 UPDATED/ENHANCED RULES
 - #31: Extended UnusedImportRule to now also detect cases where the imported class name occurs as a substring in the source code. (Thanks to René Scheibe)

--- a/src/main/groovy/org/codenarc/rule/imports/NoWildCardImportsRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/imports/NoWildCardImportsRule.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codenarc.rule.imports
+
+import org.codenarc.rule.Violation
+import org.codenarc.source.SourceCode
+
+/**
+ * Wildcard imports, static or otherwise, are not used.
+ *
+ * @author Kyle Boon
+ */
+class NoWildCardImportsRule extends AbstractImportRule {
+    String name = 'NoWildCardImports'
+    int priority = 3
+
+    void applyTo(SourceCode sourceCode, List violations) {
+        eachImportLine(sourceCode) { int lineNumber, String line ->
+            if (line.trim().endsWith('.*')) {
+                violations.add(new Violation(rule: this, sourceLine: line.trim(), lineNumber: lineNumber))
+            }
+        }
+    }
+}

--- a/src/main/resources/codenarc-base-messages.properties
+++ b/src/main/resources/codenarc-base-messages.properties
@@ -1,4 +1,3 @@
-
 ClosureStatementOnOpeningLineOfMultipleLineClosure.description=Checks for closure logic on first line (after ->) for a multi-line closure.
 ClosureStatementOnOpeningLineOfMultipleLineClosure.description.html=Checks for closure logic on first line (after ->) for a multi-line closure.
 
@@ -655,6 +654,9 @@ UnusedImport.description.html=Imports for a class that is never referenced withi
 
 MisorderedStaticImports.description=Static imports should never be declared after nonstatic imports.
 MisorderedStaticImports.description.html=Static imports should never be declared after nonstatic imports.
+
+NoWildCardImports.description=Wildcard imports, static or otherwise, are not used.
+NoWildCardImports.description.html=Wildcard imports, static or otherwise, are not used.
 
 JUnitSetUpCallsSuper.description=Checks that if the JUnit setUp() method is defined, that it includes a call to super.setUp().
 JUnitSetUpCallsSuper.description.html=Checks that if the JUnit <em>setUp()</em> method is defined, that it includes a call to <em>super.setUp()</em>.

--- a/src/main/resources/rulesets/imports.xml
+++ b/src/main/resources/rulesets/imports.xml
@@ -15,4 +15,5 @@
 
     <rule class='org.codenarc.rule.imports.ImportFromSunPackagesRule'/>
     <rule class='org.codenarc.rule.imports.MisorderedStaticImportsRule'/>
+    <rule class='org.codenarc.rule.imports.NoWildCardImportsRule'/>
 </ruleset>

--- a/src/site/apt/codenarc-rules-imports.apt
+++ b/src/site/apt/codenarc-rules-imports.apt
@@ -27,7 +27,6 @@ Imports Rules  ("<rulesets/imports.xml>")
 
 -------------------------------------------------------------------------------
     import sun.misc.foo
-    import sun.*
     import sun.misc.foo as Foo
 
     public class MyClass{}
@@ -45,8 +44,8 @@ Imports Rules  ("<rulesets/imports.xml>")
   Examples of violations:
 
 -------------------------------------------------------------------------------
-    import my.something.*
-    import static foo.bar.*
+    import my.something.another
+    import static foo.bar
 
     public class MyClass{}
 -------------------------------------------------------------------------------
@@ -74,3 +73,18 @@ Imports Rules  ("<rulesets/imports.xml>")
   * Misses unused imports if the class/alias name is contained within strings, comments or other (longer)
     names (i.e., if that string shows up almost anywhere within the source code).
 
+
+* {NoWildCardImports} Rule
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  <Since CodeNarc 0.21>
+
+  Wildcard imports, static or otherwise, are not used.
+
+  Example of violations:
+
+-------------------------------------------------------------------------------
+    import my.something.*
+    import static foo.bar.*
+
+    public class MyClass{}
+-------------------------------------------------------------------------------

--- a/src/test/groovy/org/codenarc/rule/imports/NoWildCardImportsRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/imports/NoWildCardImportsRuleTest.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codenarc.rule.imports
+
+import org.codenarc.rule.Rule
+import org.junit.Test
+import org.codenarc.rule.AbstractRuleTestCase
+
+/**
+ * Tests for NoWildCardImportsRule
+ *
+ * @author Kyle Boon
+ */
+class NoWildCardImportsRuleTest extends AbstractRuleTestCase {
+
+    @Test
+    void testRuleProperties() {
+        assert rule.priority == 3
+        assert rule.name == 'NoWildCardImports'
+    }
+
+    @Test
+    void testNoViolations() {
+        final SOURCE = '''
+            import com.google
+
+            public class Foo {}
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testSingleViolation() {
+        final SOURCE = '''
+            import com.google.*
+
+            public class Foo {}
+        '''
+        assertSingleViolation(SOURCE, 2, 'import com.google.*')
+    }
+
+    @Test
+    void testMultipleViolations() {
+        final SOURCE = '''
+            import com.google.*
+            import org.codenarc.rule.*
+
+            public class Foo {}
+        '''
+        assertViolations(SOURCE,
+            [lineNumber:2, sourceLineText:'import com.google.*'],	// todo: replace line number, source line and message
+            [lineNumber:3, sourceLineText:'import org.codenarc.rule.*'])	// todo: replace line number, source line and message
+    }
+
+    protected Rule createRule() {
+        new NoWildCardImportsRule()
+    }
+}


### PR DESCRIPTION
Google's Java Style Guide recommends no wild card imports. This helps
prevent class additions to packages from breaking things. It also makes
it easy to search for where a class is being imported from.
