### PR TITLE
Allow for opening parenthesis before opening brace

### DIFF
--- a/src/main/groovy/org/codenarc/rule/formatting/SpaceBeforeOpeningBraceRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/SpaceBeforeOpeningBraceRule.groovy
@@ -94,11 +94,15 @@ class SpaceBeforeOpeningBraceAstVisitor extends AbstractSpaceAroundBraceAstVisit
         if (isFirstVisit(expression)) {
             def line = sourceLineOrEmpty(expression)
             def startCol = expression.columnNumber
-            if (isNotWhitespace(line, startCol - 1)) {
+            if (isNotWhitespace(line, startCol - 1) && isNotOpeningParenthesis(line, startCol - 1)) {
                 addOpeningBraceViolation(expression, 'closure')
             }
         }
         super.visitClosureExpression(expression)
+    }
+
+    private static boolean isNotOpeningParenthesis(String line, int index) {
+        index >= 1 && index <= line.size() && (line[index - 1] as char) != '('
     }
 
     @Override

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceBeforeOpeningBraceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceBeforeOpeningBraceRuleTest.groovy
@@ -241,6 +241,14 @@ c        '''
         assertNoViolations(SOURCE)
     }
 
+    @Test
+    void testApplyTo_CheckClosureAsFirstMethodParameter_NoViolations() {
+        final SOURCE = '''
+            execute({ println 7 }, true)
+        '''
+        assertNoViolations(SOURCE)
+    }
+
     protected Rule createRule() {
         new SpaceBeforeOpeningBraceRule()
     }


### PR DESCRIPTION
It is helpful when closure is first parameter of method
