### PR TITLE
#61: consider importFrom includes: constraints when checking for duplicate constraint violations

### DIFF
--- a/src/test/groovy/org/codenarc/rule/grails/GrailsDuplicateConstraintRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/grails/GrailsDuplicateConstraintRuleTest.groovy
@@ -93,6 +93,51 @@ class GrailsDuplicateConstraintRuleTest extends AbstractRuleTestCase {
     }
 
     @Test
+    void testImportFrom_NoViolation() {
+        final SOURCE = '''
+            class Person {
+                String firstName
+                String lastName
+                static constraints = {
+                    importFrom Entity, include: ["firstName"]
+                    importFrom Entity, include: ["lastName"]
+                }
+            }
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testImportFrom_SameImportViolation() {
+        final SOURCE = '''
+            class Person {
+                String firstName
+                String lastName
+                static constraints = {
+                    importFrom Entity, include: ["firstName"]
+                    importFrom Entity, include: ["firstName"]
+                }
+            }
+        '''
+        assertViolations(SOURCE, [lineNumber:7, sourceLineText:'importFrom Entity, include: ["firstName"]', messageText:'The constraint for firstName in domain class Person has already been specified'])
+    }
+
+    @Test
+    void testImportFrom_ImportAndRegularConstraintViolation() {
+        final SOURCE = '''
+            class Person {
+                String firstName
+                String lastName
+                static constraints = {
+                    importFrom Entity, include: ["firstName"]
+                    firstName blank: false
+                }
+            }
+        '''
+        assertViolations(SOURCE, [lineNumber:7, sourceLineText:'firstName blank: false', messageText:'The constraint for firstName in domain class Person has already been specified'])
+    }
+
+    @Test
     void testMappingsAndConstraints_NoViolation() {
         final SOURCE = '''
             class Person {


### PR DESCRIPTION
e.g. I have some constraints that look like this:

importFrom Member, include: ["ssnLastFour"]  
importFrom Address, include: ["zipCode"]
This incorrectly results in a GrailsDuplicateConstraint violation, because the rule only looks at the method name importFrom.

I'll submit a PR for this that at least handles the include: situations. It won't be smart enough to handle including entire objects, or using the exclude parameter, but it'll at least solve these false-positive cases. Lemmeno what you think - thanks!
