### PR TITLE
PrivateFieldCouldBeFinalRule support for JPA entities

### DIFF
--- a/src/main/java/org/codenarc/util/AstUtil.java
+++ b/src/main/java/org/codenarc/util/AstUtil.java
@@ -490,6 +490,21 @@ public class AstUtil {
     }
 
     /**
+     * Return true only if the node has any of the named annotations
+     * @param node - the AST Node to check
+     * @param names - the names of the annotations
+     * @return true only if the node has any of the named annotations
+     */
+    public static boolean hasAnyAnnotation(AnnotatedNode node, String... names) {
+        for (String name : names) {
+            if (hasAnnotation(node, name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Return the List of VariableExpression objects referenced by the specified DeclarationExpression.
      * @param declarationExpression - the DeclarationExpression
      * @return the List of VariableExpression objects

--- a/src/site/apt/codenarc-rules-design.apt
+++ b/src/site/apt/codenarc-rules-design.apt
@@ -326,7 +326,10 @@ Design Rules  ("<rulesets/design.xml>")
 |                     | should be ignored (i.e., that should not cause a rule          |                        |
 |                     | violation). The names may optionally contain wildcards (*,?).  |                        |
 *---------------------+----------------------------------------------------------------+------------------------+
-
+| ignoreJpaEntities   | Specifies whether fields defined inside classes annotated      | false                  |
+|                     | with @Entity or @MappedSuperclass JPA annotations should be    |                        |
+|                     | ignored (i.e., that should not cause a rule violation).        |                        |
+*---------------------+----------------------------------------------------------------+------------------------+
 
 * {PublicInstanceField} Rule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/test/groovy/org/codenarc/rule/design/PrivateFieldCouldBeFinalRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/PrivateFieldCouldBeFinalRuleTest.groovy
@@ -414,6 +414,54 @@ class PrivateFieldCouldBeFinalRuleTest extends AbstractRuleTestCase {
         assertNoViolations(SOURCE)
     }
 
+    @Test
+    void testApplyTo_ignoreJpaEntities_Entity_NoViolations() {
+        final SOURCE = '''
+            @Entity
+            class MyClass {
+                private DateTime created = DateTime.now()
+            }
+        '''
+        rule.ignoreJpaEntities = true
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testApplyTo_ignoreJpaEntities_fullPackageEntity_NoViolations() {
+        final SOURCE = '''
+            @javax.persistence.Entity
+            class MyClass {
+                private DateTime created = DateTime.now()
+            }
+        '''
+        rule.ignoreJpaEntities = true
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testApplyTo_ignoreJpaEntities_MappedSuperclass_NoViolations() {
+        final SOURCE = '''
+            @MappedSuperclass
+            class MyClass {
+                private DateTime created = DateTime.now()
+            }
+        '''
+        rule.ignoreJpaEntities = true
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testApplyTo_ignoreJpaEntities_fullPackageMappedSuperclass_NoViolations() {
+        final SOURCE = '''
+            @javax.persistence.MappedSuperclass
+            class MyClass {
+                private DateTime created = DateTime.now()
+            }
+        '''
+        rule.ignoreJpaEntities = true
+        assertNoViolations(SOURCE)
+    }
+
     protected Rule createRule() {
         new PrivateFieldCouldBeFinalRule()
     }

--- a/src/test/groovy/org/codenarc/util/AstUtilTest.groovy
+++ b/src/test/groovy/org/codenarc/util/AstUtilTest.groovy
@@ -54,6 +54,7 @@ class AstUtilTest extends AbstractTestCase {
                     2, 3)
             }
             @Before setUp() {  }
+            @First @Second def twoAnnotationsMethod() { }
         }
         enum MyEnum {
             READ, WRITE
@@ -221,9 +222,17 @@ class AstUtilTest extends AbstractTestCase {
     }
 
     @Test
-    void testHashAnnotation() {
+    void testHasAnnotation() {
         assert !AstUtil.hasAnnotation(visitor.methodNodes['setUp'], 'doesNotExist')
         assert AstUtil.hasAnnotation(visitor.methodNodes['setUp'], 'Before')
+    }
+
+    @Test
+    void testHasAnyAnnotation() {
+        assert !AstUtil.hasAnyAnnotation(visitor.methodNodes['twoAnnotationsMethod'], 'doesNotExist')
+        assert AstUtil.hasAnyAnnotation(visitor.methodNodes['twoAnnotationsMethod'], 'First')
+        assert AstUtil.hasAnyAnnotation(visitor.methodNodes['twoAnnotationsMethod'], 'doesNotExist', 'First')
+        assert AstUtil.hasAnyAnnotation(visitor.methodNodes['twoAnnotationsMethod'], 'doesNotExist', 'First', 'Second')
     }
 
     @Test


### PR DESCRIPTION
PrivateFieldCouldBeFinalRule is often not desirable for  fields defined in entity classes. I added new property "ignoreJpaEntities" to aforementioned rule. When the property is set to true, fields inside classes annotated with @Entity or @MappedSuperclass are ignored. 
I observed that PrivateFieldCouldBeFinalRule violations often happen in entity classes (persisted fields in fact should not be final) and at the same time I don't want to disable PrivateFieldCouldBeFinalRule fully. I just want it to be configurable to ignore JPA entities.

I also added new method boolean hasAnyAnnotation(AnnotatedNode node, String... names) to AstUtil.
Everything is tested.
