### PR TITLE
Added support for JUnit's ExpectedException way to verify exceptions.

### DIFF
--- a/src/main/groovy/org/codenarc/rule/junit/JUnitTestMethodWithoutAssertRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/junit/JUnitTestMethodWithoutAssertRule.groovy
@@ -40,7 +40,7 @@ class JUnitTestMethodWithoutAssertRule extends AbstractAstVisitorRule {
 
     String name = 'JUnitTestMethodWithoutAssert'
     int priority = 2
-    String assertMethodPatterns = 'assert.*,should.*,fail.*,verify.*'
+    String assertMethodPatterns = 'assert.*,should.*,fail.*,verify.*,expect.*'
     String applyToClassNames = DEFAULT_TEST_CLASS_NAMES
 
     @Override

--- a/src/site/apt/codenarc-rules-junit.apt
+++ b/src/site/apt/codenarc-rules-junit.apt
@@ -301,12 +301,13 @@ JUnit Rules  ("<rulesets/junit.xml>")
   starts with the work assert, like assertEquals, assertNull, or assertMyClassIsSimilar. Also, any method named
   <<<should.*>>> also counts as an assertion so that <<<shouldFail>>> methods do not trigger an assertion, any method
   that starts with <<<fail>> counts as an assertion, and any method that starts with <<<verify>>> counts as an assertion.
+  Since version 0.23 CodeNarc has support for JUnit's ExpectedException.
 
   What counts as an assertion method can be overridden using the assertMethodPatterns property of the rule. The
   default value is this comma separated list of regular expressions:
 
 -------------------------------------------------------------------------------
-        String assertMethodPatterns = 'assert.*,should.*,fail.*,verify.*'
+    String assertMethodPatterns = 'assert.*,should.*,fail.*,verify.*,expect.*'
 -------------------------------------------------------------------------------
 
     If you'd like to add any method starting with 'ensure' to the ignores then you would set the value to this:

--- a/src/test/groovy/org/codenarc/rule/junit/JUnitTestMethodWithoutAssertRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/JUnitTestMethodWithoutAssertRuleTest.groovy
@@ -163,6 +163,29 @@ class JUnitTestMethodWithoutAssertRuleTest extends AbstractRuleTestCase {
                 12, 'void someMethod2()', "Test method 'someMethod2' makes no assertions")
     }
 
+    @Test
+    void testNoViolations_ExpectedExceptionSupport() {
+        assertNoViolations('''
+            class MyTest {
+                @Rule
+                public ExpectedException exception = ExpectedException.none()
+
+                @Test
+                void myTest() {
+                    String nullString = null
+                    exception.expect(NullPointerException)
+                    nullString.toLowerCase()
+                }
+
+                @Test
+                void myTest2() {
+                    exception.expectMessage('argument')
+                    throw new IllegalArgumentException('Illegal argument provided!')
+                }
+            }
+        ''')
+    }
+
     protected Rule createRule() {
         new JUnitTestMethodWithoutAssertRule()
     }


### PR DESCRIPTION
JUnit has an additional, improved way to verify exceptions - @Rule ExpectedException. 
More information: http://stackoverflow.com/a/2935935/568664

Added support for ExpectedException to JUnitTestMethodWithoutAssert rule.
