### PR TITLE
Allow regular comments or annotations before Javadoc section

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,12 @@ CodeNarc Change Log
 -------------------------------------------------------------------------------
 http://www.codenarc.org
 
+Changes in version 0.24 (??? 2015)
+--------------------------------------
+UPDATED/ENHANCED RULES AND BUG FIXES
+- #81: ClassJavadoc: Allow regular comments or annotations before Javadoc section.
+
+
 Changes in version 0.23 (Feb 2015)
 --------------------------------------
 NEW RULES

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,7 +5,7 @@ http://www.codenarc.org
 Changes in version 0.24 (??? 2015)
 --------------------------------------
 UPDATED/ENHANCED RULES AND BUG FIXES
-- #81: ClassJavadoc: Allow regular comments or annotations before Javadoc section.
+- #91: ClassJavadoc: Allow regular comments or annotations before Javadoc section.
 
 
 Changes in version 0.23 (Feb 2015)

--- a/src/main/groovy/org/codenarc/rule/formatting/ClassJavadocRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/ClassJavadocRule.groovy
@@ -49,13 +49,24 @@ class ClassJavadocRule extends AbstractRule {
             
             if (classNode.isPrimaryClassNode() && classNode.superClass.name != 'java.lang.Enum') {
                 def index = classNode.lineNumber - 1
-
-                while (lines[--index].trim().startsWith('*') || lines[index].trim().isEmpty()) {
-                    /* Do nothing, to simulate an until loop */
+                boolean isValidLineBeforeStartfOfJavadoc = true
+                
+                while (index > 0 && isValidLineBeforeStartfOfJavadoc) {
+                    String currentLineTrimmed = lines[--index].trim()
+                    
+                    // Valid lines before the start of the javadoc are:
+                    // - a blank line
+                    isValidLineBeforeStartfOfJavadoc = currentLineTrimmed.isEmpty()
+                    // - a regular comment
+                    isValidLineBeforeStartfOfJavadoc |= currentLineTrimmed.startsWith('//')
+                    // - a class annotation
+                    isValidLineBeforeStartfOfJavadoc |= currentLineTrimmed.startsWith('@')
+                    // - a line of javadoc
+                    isValidLineBeforeStartfOfJavadoc |= currentLineTrimmed.startsWith('*')
                 }
 
                 if (!lines[index].trim().startsWith('/**')) {
-                    violations.add(createViolation(sourceCode, classNode, "Class $classNode.name missing JavaDoc"))
+                    violations.add(createViolation(sourceCode, classNode, "Class $classNode.name missing Javadoc"))
                 }
             }
         }

--- a/src/test/groovy/org/codenarc/rule/formatting/ClassJavadocRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/ClassJavadocRuleTest.groovy
@@ -94,6 +94,67 @@ class ClassJavadocRuleTest extends AbstractRuleTestCase {
     }
 
     @Test
+    void testHasInlineJavadoc_WithinPackage_NoViolations() {
+        final SOURCE = '''
+            package org.example
+
+            /** Javadoc */
+            class TestClass {
+            }
+        '''
+        sourceCodeName = 'TestClass.groovy'
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testHasJavadoc_WithinPackage_WithRegularComment_NoViolations() {
+        final SOURCE = '''
+            package org.example
+
+            /**
+             * Javadoc
+             */
+            // Not javadoc
+            class TestClass {
+            }
+        '''
+        sourceCodeName = 'TestClass.groovy'
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testHasJavadoc_WithinPackage_WithAnnotation_NoViolations() {
+        final SOURCE = '''
+            package org.example
+
+            /**
+             * Javadoc
+             */
+            @ToString
+            class TestClass {
+            }
+        '''
+        sourceCodeName = 'TestClass.groovy'
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testHasJavadoc_WithinPackage_WithCommentedAnnotation_NoViolations() {
+        final SOURCE = '''
+            package org.example
+
+            /**
+             * Javadoc
+             */
+            //@ToString
+            class TestClass {
+            }
+        '''
+        sourceCodeName = 'TestClass.groovy'
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
     void testMissingJavadoc_WithinPackage_Violation() {
         final SOURCE = '''
             package org.example
@@ -104,7 +165,7 @@ class ClassJavadocRuleTest extends AbstractRuleTestCase {
         '''
         sourceCodeName = 'TestClass.Groovy'
         assertViolations(SOURCE,
-            [lineNumber:5, sourceLineText:'class TestClass', messageText:'Class org.example.TestClass missing JavaDoc'])
+            [lineNumber:5, sourceLineText:'class TestClass', messageText:'Class org.example.TestClass missing Javadoc'])
     }
 
     @Test
@@ -123,8 +184,8 @@ class ClassJavadocRuleTest extends AbstractRuleTestCase {
         sourceCodeName = 'MyClass.groovy'
 
         assertViolations(SOURCE,
-                [lineNumber: 4, sourceLineText: 'class MyClass', messageText: 'Class org.example.MyClass missing JavaDoc'],
-                [lineNumber: 8, sourceLineText: 'class OtherClass', messageText: 'Class org.example.OtherClass missing JavaDoc'])
+                [lineNumber: 4, sourceLineText: 'class MyClass', messageText: 'Class org.example.MyClass missing Javadoc'],
+                [lineNumber: 8, sourceLineText: 'class OtherClass', messageText: 'Class org.example.OtherClass missing Javadoc'])
     }
 
     @Test


### PR DESCRIPTION
- supporting lines starting with '//' or '@' before the Javadoc
- renaming JavaDoc to Javadoc