### PR TITLE
Releasing basic configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: 'groovy'
-apply plugin: 'maven'
+plugins {
+    id 'groovy'
+    id 'maven'
+    id 'net.researchgate.release' version '2.0.2'
+}
 
 sourceCompatibility = '1.6'
 targetCompatibility = '1.6'
@@ -29,4 +32,9 @@ test {
     testLogging {
         events 'passed', 'skipped', 'failed'
     }
+}
+
+release {
+    tagPrefix = project.name
+    requireBranch = '' // disabled
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-group = org.codenarc
-version = 0.24-SNAPSHOT
+group=org.codenarc
+version=0.24-SNAPSHOT
 
-groovyVersion = 2.4.3
+groovyVersion=2.4.3


### PR DESCRIPTION
Release plugin applied for Gradle.

Typical stuff, increments version, does two commits, one tag (name adjusted to match latest tags format).
`requireBranch` check disabled as I'm not sure from which branch do you release. As well It may be tested from any other branch this way.

If you like anything adjusted differently than default here's plugin's doc page: https://github.com/researchgate/gradle-release

According to the mentioned doc and for the sake of consistency I've changed plugins declaration way to the ['new one'](http://www.gradle.org/docs/current/dsl/org.gradle.plugin.use.PluginDependenciesSpec.html). It's still in 'incubating', build works well though and it's cleaner without the whole additional `buildscript` block.

I had to remove some spaces from gradle.properties file as the plugin wasn't able to update version.

No maven repo deployment setup yet. It'll come with separate PR.