### PR TITLE
Fix missing property in maven publishing config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,11 +65,11 @@ uploadArchives {
             beforeDeployment { deployment -> signing.signPom(deployment) }
 
             repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
+                authentication(userName: properties['ossrhUsername'], password: properties['ossrhPassword'])
             }
 
             snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
+                authentication(userName: properties['ossrhUsername'], password: properties['ossrhPassword'])
             }
 
             pom.project {


### PR DESCRIPTION
...and you go like `./gradlew uploadArchives -PossrhUsername=christmar -PossrhPassword=plop`.

Or in your local $GRADLE_USER_HOME/gradle.properties set relevant properties like:
```
ossrhUsername=christmar
ossrhPassword=plop
```
No need for extra command line params then.