### PR TITLE
  fix FileEndsWithoutNewlineRule to handle empty source

### DIFF
--- a/src/main/groovy/org/codenarc/rule/formatting/FileEndsWithoutNewlineRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/FileEndsWithoutNewlineRule.groovy
@@ -35,7 +35,7 @@ class FileEndsWithoutNewlineRule extends AbstractRule {
      */
     @Override
     void applyTo(SourceCode sourceCode, List violations) {
-        if (!sourceCode.text.endsWith('\n')) {
+        if (!sourceCode.text.endsWith('\n') && sourceCode.lines) {
             violations.add(createViolation(sourceCode.lines.size() - 1, sourceCode.lines[-1],
                 "File $sourceCode.name does not end with a newline"))
         }

--- a/src/main/groovy/org/codenarc/source/SourceString.groovy
+++ b/src/main/groovy/org/codenarc/source/SourceString.groovy
@@ -31,12 +31,12 @@ class SourceString extends AbstractSourceCode {
 
     /**
      * Construct a new instance for the file at the specified path
-     * @param source - the source; must not be null or empty
+     * @param source - the source code; may be empty
      * @param path - the path for the source code; may be null; defaults to null
      * @param name - the name for the source code; may be null; defaults to null
      */
     SourceString(String source, String path=null, String name=null) {
-        assert source
+        assert source != null
         this.source = source
         setPath(path)
         this.name = name

--- a/src/test/groovy/org/codenarc/rule/formatting/FileEndsWithoutNewlineRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/FileEndsWithoutNewlineRuleTest.groovy
@@ -54,6 +54,12 @@ class FileEndsWithoutNewlineRuleTest extends AbstractRuleTestCase {
         assertSingleViolation(SOURCE, 3, '}', 'File null does not end with a newline')
     }
 
+    @Test
+    void testEmptySource() {
+        final SOURCE = ''
+        assertNoViolations(SOURCE)
+    }
+
     protected Rule createRule() {
         new FileEndsWithoutNewlineRule()
     }

--- a/src/test/groovy/org/codenarc/source/SourceStringTest.groovy
+++ b/src/test/groovy/org/codenarc/source/SourceStringTest.groovy
@@ -45,7 +45,7 @@ class SourceStringTest extends AbstractTestCase {
 
     @Test
     void testConstructor_EmptySource() {
-        shouldFail { new SourceString('') }
+        assert new SourceString('').text == ''
     }
 
     @Test


### PR DESCRIPTION
otherwise the following error is thrown:

    ERROR: Negative array index [-1] too large for array size 0
    java.lang.ArrayIndexOutOfBoundsException: Negative array index [-1] too large for array size 0
            at org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport.normaliseIndex(DefaultGroovyMethodsSupport.java:74)
            at org.codehaus.groovy.runtime.DefaultGroovyMethods.getAt(DefaultGroovyMethods.java:7110)
            ...
            at org.codenarc.rule.formatting.FileEndsWithoutNewlineRule.applyTo(FileEndsWithoutNewlineRule.groovy:39)