### PR TITLE
UnnecessaryConstructor: add rule to (not) ignore annotations

### DIFF
--- a/src/main/groovy/org/codenarc/rule/unnecessary/UnnecessaryConstructorRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/unnecessary/UnnecessaryConstructorRule.groovy
@@ -36,6 +36,7 @@ class UnnecessaryConstructorRule extends AbstractAstVisitorRule {
     String name = 'UnnecessaryConstructor'
     int priority = 3
     Class astVisitorClass = UnnecessaryConstructorAstVisitor
+    boolean ignoreAnnotations = false
 }
 
 class UnnecessaryConstructorAstVisitor extends AbstractAstVisitor {
@@ -48,7 +49,8 @@ class UnnecessaryConstructorAstVisitor extends AbstractAstVisitor {
     }
 
     private void analyzeConstructor(ConstructorNode node) {
-        if(isEmptyOrJustCallsSuper(node) && !Modifier.isPrivate(node.modifiers) && node.parameters?.size() == 0) {
+        if(isEmptyOrJustCallsSuper(node) && (!rule.ignoreAnnotations || !hasAnnotations(node)) &&
+                !Modifier.isPrivate(node.modifiers) && node.parameters?.size() == 0) {
              addViolation node, 'The constructor can be safely deleted'
         }
     }
@@ -71,5 +73,9 @@ class UnnecessaryConstructorAstVisitor extends AbstractAstVisitor {
             onlyStatement.expression instanceof ConstructorCallExpression &&
             onlyStatement.expression.superCall &&
             onlyStatement.expression.arguments.expressions.empty
+    }
+
+    private boolean hasAnnotations(ConstructorNode node) {
+        !node.annotations.empty
     }
 }

--- a/src/site/apt/codenarc-rules-unnecessary.apt
+++ b/src/site/apt/codenarc-rules-unnecessary.apt
@@ -313,6 +313,13 @@ Unnecessary Rules  ("<rulesets/unnecessary.xml>")
   This rule detects when a constructor is not necessary; i.e., when there's only one constructor, it's
   <<<public>>>, has an empty body, and takes no arguments, or else contains only a single call to <<<super()>>>.
 
+*-------------------+----------------------------------------------------------------+-------------------+
+| <<Property>>      | <<Description>>                                                | <<Default Value>> |
+*-------------------+----------------------------------------------------------------+-------------------+
+| ignoreAnnotations | If <<<true>>>, then do not report violations if a constructor  | false             |
+|                   | has one or more annotations.                                   |                   |
+*-------------------+----------------------------------------------------------------+-------------------+
+
   Example of violations:
 
 -------------------------------------------------------------------------------

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryConstructorRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryConstructorRuleTest.groovy
@@ -31,6 +31,7 @@ class UnnecessaryConstructorRuleTest extends AbstractRuleTestCase {
     void testRuleProperties() {
         assert rule.priority == 3
         assert rule.name == 'UnnecessaryConstructor'
+        assert rule.ignoreAnnotations == false
     }
 
     @Test
@@ -125,6 +126,29 @@ class UnnecessaryConstructorRuleTest extends AbstractRuleTestCase {
             }
         '''
         assertSingleViolation(SOURCE, 5, 'public MyInnerClass() {}', 'The constructor can be safely deleted')
+    }
+
+    @Test
+    void testAnnotation() {
+        final SOURCE = '''
+            class MyClass {
+                @Deprecated
+                MyClass() {}
+            }
+        '''
+        assertSingleViolation(SOURCE, 4, 'MyClass() {}', 'The constructor can be safely deleted')
+    }
+
+    @Test
+    void testIgnoreAnnotation() {
+        final SOURCE = '''
+            class MyClass {
+                @Deprecated
+                MyClass() {}
+            }
+        '''
+        rule.ignoreAnnotations = true
+        assertNoViolations(SOURCE)
     }
 
     protected Rule createRule() {


### PR DESCRIPTION
Empty constructors with annotations currently cause a UnnecessaryConstructor violation.

But some frameworks require annotations on otherwise empty constructurs, e.g. `@DataBoundConstructor` in [Stapler](https://github.com/stapler/stapler). Or sometimes it's necessary to mark an empty default constructor as deprecated.

This PR adds an option to UnnecessaryConstructor to allow empty constructors with annotations. It keeps the existing behavior as default.