### PR TITLE
UnnecessaryPublicModifierRule should not include generics method

### DIFF
--- a/src/main/groovy/org/codenarc/rule/unnecessary/UnnecessaryPublicModifierRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/unnecessary/UnnecessaryPublicModifierRule.groovy
@@ -47,7 +47,9 @@ class UnnecessaryPublicModifierAstVisitor extends AbstractAstVisitor {
 
     @Override
     void visitMethodEx(MethodNode node) {
-        checkDeclaration(node, node.name, 'methods')
+        if (node.genericsTypes == null || node.genericsTypes.length == 0) {
+            checkDeclaration(node, node.name, 'methods')
+        }
         super.visitMethodEx(node)
     }
 

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryPublicModifierRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryPublicModifierRuleTest.groovy
@@ -133,6 +133,46 @@ class UnnecessaryPublicModifierRuleTest extends AbstractRuleTestCase {
         assert warnMessages.empty
     }
 
+    @Test
+    void testPublicGenericClass() {
+        final SOURCE = '''
+            public class MyClass<T> {
+                T someProperty
+            }
+        '''
+        assertSingleViolation(SOURCE, 2, 'public class MyClass<T>', 'The public keyword is unnecessary for classes')
+    }
+
+    @Test
+    void testPublicGenericMethodWithReturnGenericType() {
+        final SOURCE = '''
+             class MyClass {
+                public <T> T myMethod() { }
+            }
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testPublicGenericMethodWithVoidReturnType() {
+        final SOURCE = '''
+             class MyClass {
+                public <T> void myMethod(T t) { }
+            }
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testPublicGenericConstructor() {
+        final SOURCE = '''
+             class MyClass<T, K> {
+                public MyClass(T t, K k) { }
+            }
+        '''
+        assertSingleViolation(SOURCE, 3, 'public MyClass(T t, K k) { }', 'The public keyword is unnecessary for constructors')
+    }
+
     protected Rule createRule() {
         new UnnecessaryPublicModifierRule()
     }


### PR DESCRIPTION
Since groovy parser does not handle generics method without modifier in front, we are forced to add one.
Link to issue:
http://stackoverflow.com/questions/11395527/groovy-generics-failure