### PR TITLE
Add ability to exclude files by name for NoDef rule

### DIFF
--- a/src/main/groovy/org/codenarc/rule/convention/NoDefRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/convention/NoDefRule.groovy
@@ -34,15 +34,19 @@ class NoDefRule extends AbstractRule {
     int priority = 3
     protected static final String MESSAGE = 'def should not be used'
     String excludeRegex
+    String excludeFilesRegex
 
     @Override
     void applyTo(SourceCode sourceCode, List<Violation> violations) {
         Pattern excludeFilter = excludeRegex ? ~/.*def\s+$excludeRegex.*/ : null
-        sourceCode.lines.eachWithIndex {
-            String line, int idx ->
-                if (line.contains('def ') && (!excludeFilter || !(line ==~ excludeFilter))) {
-                    violations << createViolation(idx + 1, line.trim(), MESSAGE)
-                }
+        Pattern excludeFiles = excludeFilesRegex ? ~/$excludeFilesRegex/ : null
+        if (excludeFiles && !(sourceCode.name ==~ excludeFiles)) {
+            sourceCode.lines.eachWithIndex {
+                String line, int idx ->
+                    if (line.contains('def ') && (!excludeFilter || !(line ==~ excludeFilter))) {
+                        violations << createViolation(idx + 1, line.trim(), MESSAGE)
+                    }
+            }
         }
     }
 }

--- a/src/main/groovy/org/codenarc/rule/convention/NoDefRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/convention/NoDefRule.groovy
@@ -40,7 +40,7 @@ class NoDefRule extends AbstractRule {
     void applyTo(SourceCode sourceCode, List<Violation> violations) {
         Pattern excludeFilter = excludeRegex ? ~/.*def\s+$excludeRegex.*/ : null
         Pattern excludeFiles = excludeFilesRegex ? ~/$excludeFilesRegex/ : null
-        if (excludeFiles && !(sourceCode.name ==~ excludeFiles)) {
+        if (!excludeFiles || (!sourceCode.name || (!(sourceCode.name ==~ excludeFiles)))) {
             sourceCode.lines.eachWithIndex {
                 String line, int idx ->
                     if (line.contains('def ') && (!excludeFilter || !(line ==~ excludeFilter))) {


### PR DESCRIPTION
It's ok for Grails controller actions to be called something like `def index()`, so I'd like the NoDef rule to not apply in classes called `.*Controller`.