### PR TITLE
fix NPE in MissingBlankLineAfterPackageRule for source containing only a package

### DIFF
--- a/src/main/groovy/org/codenarc/rule/formatting/MissingBlankLineAfterPackageRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/MissingBlankLineAfterPackageRule.groovy
@@ -31,11 +31,13 @@ class MissingBlankLineAfterPackageRule extends AbstractRule {
 
     @Override
     void applyTo(SourceCode sourceCode, List violations) {
-
         PackageNode packageNode = sourceCode.ast?.package
-        if (packageNode && !sourceCode.line(packageNode.lineNumber).isEmpty()) {
-            violations.add(createViolation(packageNode.lineNumber, sourceCode.line(packageNode.lineNumber),
-                "Missing blank line after package statement in file $sourceCode.name"))
+        if (packageNode) {
+            String sourceCodeLine = sourceCode.line(packageNode.lineNumber)
+            if (sourceCodeLine != null && !sourceCodeLine.isEmpty()) {
+                violations.add(createViolation(packageNode.lineNumber, sourceCodeLine,
+                    "Missing blank line after package statement in file $sourceCode.name"))
+            }
         }
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/MissingBlankLineAfterPackageRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/MissingBlankLineAfterPackageRuleTest.groovy
@@ -34,6 +34,15 @@ class MissingBlankLineAfterPackageRuleTest extends AbstractRuleTestCase {
     }
 
     @Test
+    void testSuccessScenarioOnlyPackage() {
+        final SOURCE = '''\
+            /** some package comment */
+            package org.codenarc
+            '''.stripIndent()
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
     void testSuccessScenarioWithoutPackage() {
         final SOURCE = '''\
             class MyClass {


### PR DESCRIPTION
Applying `MissingBlankLineAfterPackageRule` to a file containing only a package:

```
/** some package comment */
package org.codenarc
```


throws this exceptions:

```
java.lang.NullPointerException: Cannot invoke method isEmpty() on null object
	at org.codehaus.groovy.runtime.NullObject.invokeMethod(NullObject.java:88)
	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:45)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45)
	at org.codehaus.groovy.runtime.callsite.NullCallSite.call(NullCallSite.java:32)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45)
	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:54)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:112)
	at org.codenarc.rule.formatting.MissingBlankLineAfterPackageRule.applyTo(MissingBlankLineAfterPackageRule.groovy:36)
```