### PR TITLE
fix the error message in the logs from the space after closing brace rule

### DIFF
--- a/src/main/groovy/org/codenarc/rule/formatting/SpaceAfterClosingBraceRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/SpaceAfterClosingBraceRule.groovy
@@ -118,7 +118,7 @@ class SpaceAfterClosingBraceAstVisitor extends AbstractSpaceAroundBraceAstVisito
         if (!rule.checkClosureMapEntryValue && expression.valueExpression instanceof ClosureExpression) {
             isFirstVisit(expression.valueExpression)   // Register the closure so that it will be ignored in visitClosureExpression()
         } else if (!rule.checkClosureMapEntryValue && expression.valueExpression.hasProperty('arguments')) {
-            if (expression.valueExpression.arguments.last() instanceof ClosureExpression ) {
+            if (!expression.valueExpression.arguments.expressions.isEmpty() && expression.valueExpression.arguments.last() instanceof ClosureExpression ) {
                 isFirstVisit(expression.valueExpression.arguments.last())
             }
         }


### PR DESCRIPTION
Unfortunately, I'm a little stumped by this one.  The errors in the logs like the one below: 
<img width="1117" alt="screen shot 2017-04-09 at 5 50 58 pm" src="https://cloud.githubusercontent.com/assets/4601577/24838712/d0339f86-1d4d-11e7-8e89-0ff31a48ebeb.png">
come from `RunCodeNarcAgainstProjectSourceCodeTest`.  Since the errors are only in the logs and they aren't violations, it didn't fail in the initial pull request.  I cannot replicate it in the tests even using the same source code from the files it complains about in the logs.  However, this fix seems to resolve the messages.  I would appreciate feedback especially if someone can figure out how to write a failing test for it.