### PR TITLE
ci: enable gradle caching in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
 language: groovy
 
 install: true
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/


### PR DESCRIPTION
Speed up the Travis build by using its [dependency cache](https://docs.travis-ci.com/user/languages/java/#Caching).