### PR TITLE
Don't run BracesForClassRule against script ClassNodes

### DIFF
--- a/src/main/groovy/org/codenarc/rule/formatting/BracesForClassRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/BracesForClassRule.groovy
@@ -37,12 +37,14 @@ class BracesForClassRule extends AbstractRule {
     void applyTo(SourceCode sourceCode, List violations) {
 
         sourceCode?.ast?.classes?.each { ClassNode classNode ->
-
-            def (lineNumber, sourceLine) = findOpeningBraceLine(sourceCode, classNode)
-            // Groovy 1.7 returns -1 as line number for a ClassNode representing an enum.
-            // In this case we ignore the rule
-            if (lineNumber != -1) {
-                applyToClassNode(classNode, lineNumber, sourceLine, violations)
+            // Scripts don't have opening and closing braces, so ignore them.
+            if (!classNode.script) {
+                def (lineNumber, sourceLine) = findOpeningBraceLine(sourceCode, classNode)
+                // Groovy 1.7 returns -1 as line number for a ClassNode representing an enum.
+                // In this case we ignore the rule
+                if (lineNumber != -1) {
+                    applyToClassNode(classNode, lineNumber, sourceLine, violations)
+                }
             }
         }
     }

--- a/src/test/groovy/org/codenarc/rule/formatting/BracesForClassRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/BracesForClassRuleTest.groovy
@@ -211,6 +211,17 @@ class BracesForClassRuleTest extends AbstractRuleTestCase {
                 [lineNumber: 49, sourceLineText: 'private class Forth {', messageText: 'Opening brace for the class Forth should start on a new line'])
     }
 
+    @Test
+    void testNoViolationForScriptClassNodes() {
+        final SOURCE = '''
+             def x = """
+             {
+             }
+             """
+        '''
+        assertNoViolations(SOURCE)
+    }
+
     protected Rule createRule() {
         new BracesForClassRule()
     }


### PR DESCRIPTION
Scripts do not have opening and closing braces, so in rare situations this
check will backfire and report a violation of this rule, for example when
run against the following script:

def x = """
{
}
"""