### PR TITLE
Use the right classloader for loading AST transformations when compiling analysed code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /hamlet_docs
 /*.patch
 /*.iws
-/*.iml
+*.iml
 /*.ipr
 /AntBuilderTestXmlReport.xml
 /*.html
@@ -20,3 +20,4 @@ build/
 src/main/java/META-INF/
 /.gradle
 /classes
+/out

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'groovy'
+    id 'idea'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testCompile project(':')
+    testCompile gradleTestKit()
+}
+
+configurations.all {
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        if (details.requested.group == 'org.codehaus.groovy' && details.requested.version == '2.4.12') {
+            details.useVersion '2.4.11'
+        }
+    }
+}
+
+test {
+    systemProperty 'codenarc.test.projectPath', rootProject.projectDir.absolutePath
+}

--- a/integration-test/src/test/groovy/org/codenarc/gradle/GradlePluginCompilationClasspathTest.groovy
+++ b/integration-test/src/test/groovy/org/codenarc/gradle/GradlePluginCompilationClasspathTest.groovy
@@ -1,0 +1,92 @@
+package org.codenarc.gradle
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class GradlePluginCompilationClasspathTest {
+
+    private final static String CONFIG_FILE_DIRECTORY = 'config/codenarc'
+    private final static String CONFIG_FILE_PATH = "$CONFIG_FILE_DIRECTORY/rulesets.groovy"
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    @Test
+    void testRunningEnhancedRulesFromGradleBuildOnCodeThatUsesAstTransformations() {
+        gradleBuildWithCodeNarcCompilationClasspathConfigured()
+        cloneWithoutCloneableRuleEnabled()
+        codeViolatingCloneWithoutCloneableRuleAndUsingAstTransformations()
+
+        def result = runFailingCodeNarcTaskForMainSourceSet()
+
+        assert result.output.contains('CodeNarc rule violations were found')
+    }
+
+    private BuildResult runFailingCodeNarcTaskForMainSourceSet() {
+        GradleRunner.create()
+            .withGradleVersion('4.2-20170813022644+0000') //this line can be removed as soon as Gradle 4.2 is released and the build is updated to that version
+            .withProjectDir(temporaryFolder.root)
+            .withArguments('codenarcMain')
+            .buildAndFail()
+    }
+
+    private void gradleBuildWithCodeNarcCompilationClasspathConfigured() {
+        temporaryFolder.newFile('build.gradle') << """
+            apply plugin: "codenarc"
+            apply plugin: "groovy"
+
+            repositories {
+                mavenCentral()
+            }
+
+            codenarc {
+                codenarc.configFile = file('$CONFIG_FILE_PATH')
+            }
+            
+            dependencies {
+                compile localGroovy()
+                codenarc localGroovy() 
+                codenarc files(${codeNarcClassesDirs().collect { "'$it'" }.join(', ')})
+            }
+            
+            codenarcMain {
+                compilationClasspath = sourceSets.main.compileClasspath 
+            }
+        """
+    }
+
+    private void cloneWithoutCloneableRuleEnabled() {
+        new File(temporaryFolder.root, CONFIG_FILE_DIRECTORY).mkdirs()
+        temporaryFolder.newFile(CONFIG_FILE_PATH) << '''
+            ruleset {
+                CloneWithoutCloneable
+            }
+        '''
+    }
+
+    private codeViolatingCloneWithoutCloneableRuleAndUsingAstTransformations() {
+        def srcDir = "src/main/groovy/"
+        new File(temporaryFolder.root, srcDir).mkdirs()
+        temporaryFolder.newFile("$srcDir/ViolatingClass.groovy") << '''
+            import groovy.transform.EqualsAndHashCode
+            
+            @EqualsAndHashCode
+            class ViolatingClass extends Tuple {
+                ViolatingClass clone() {}
+            }
+        '''
+    }
+
+    private List<String> codeNarcClassesDirs() {
+        def gradleProjectPath = System.getProperty('codenarc.test.projectPath')
+        if (gradleProjectPath) {
+            ["$gradleProjectPath/build/classes/groovy/main", "$gradleProjectPath/build/resources/main"]
+        } else {
+            [new File('out/production/CodeNarc').absolutePath]
+        }
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
+include 'integration-test'
+
 rootProject.name = 'CodeNarc'

--- a/src/main/groovy/org/codenarc/source/AbstractSourceCode.groovy
+++ b/src/main/groovy/org/codenarc/source/AbstractSourceCode.groovy
@@ -85,7 +85,8 @@ abstract class AbstractSourceCode implements SourceCode {
         synchronized (initLock) {
             if (!astParsed) {
                 SourceUnit unit = SourceUnit.create('None', getText())
-                CompilationUnit compUnit = new CompilationUnit()
+                GroovyClassLoader transformLoader = new GroovyClassLoader(getClass().classLoader)
+                CompilationUnit compUnit = new CompilationUnit(null, null, null, transformLoader)
                 compUnit.addSource(unit)
                 try {
                     removeGrabTransformation(compUnit)


### PR DESCRIPTION
Closes #218.

Notes:
1. I had to create a submodule for the Gradle integration test because of conflicting Groovy versions. After upgrading to GMetrics to `1.0` CodeNarc is now depending on and compiled against Groovy `2.4.12` (even though the build is specifying the version as `2.1.8` in `gradle.properties`) but using Gradle Test Kit from Gradle `4.0` (current version used by the build) forces Groovy version to be `2.4.11`. I didn't want to to force a different version of Groovy when running all tests compared to what is used for compilation hence I created a separate submodule which is using `2.4.11` for that single Gradle integraiton test. We could update to Gradle 4.1 which should make Groovy required by the Test Kit to be `2.4.12` which in turn would allow us to get rid of that submodule but I'm not sure we want to tie Groovy version used to compile CodeNarc with the one used by Gradle for its runtime.
1. Support for CodeNarc Ant task's `classpath` property has not been yet officially released in Gradle hence the integration test is using a nightly build, namely `4.2-20170813022644+0000`. As I've mentioned in a comment in that test, we should probably change that test to use `4.2` when it's released.