### PR TITLE
Change dependency substitutions to exclusions in integration-test module

### DIFF
--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -8,17 +8,11 @@ repositories {
 }
 
 dependencies {
-    testCompile project(':')
+    testCompile project(':'), {
+        exclude group: 'org.codehaus.groovy'
+    }
     testCompile gradleTestKit()
     testCompile 'junit:junit:4.12'
-}
-
-configurations.all {
-    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-        if (details.requested.group == 'org.codehaus.groovy' && details.requested.version == '2.4.12') {
-            details.useVersion '2.4.11'
-        }
-    }
 }
 
 test {


### PR DESCRIPTION
This ensures that the build does not need to be modified every single time the versions of groovy or gradle used are changed