### PR TITLE
Removing duplicate gradle property settings.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,4 @@
 #Sun, 21 Feb 2016 16:50:32 -0500
-group=org.codenarc
-version=0.26
 
 groovyVersion=2.3.11
 #groovyVersion=2.1.8


### PR DESCRIPTION
`group` and `version` are both defined in build.gradle already.