### PR TITLE
TrailingComma Rules - Allowing inline Lists in Annotations

### DIFF
--- a/src/main/groovy/org/codenarc/rule/convention/TrailingCommaRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/convention/TrailingCommaRule.groovy
@@ -56,7 +56,10 @@ class TrailingCommaAstVisitor extends AbstractAstVisitor {
         if (isOneLiner(expression) || expression.expressions.isEmpty()) {
             return
         }
-        if (rule.checkList && !hasTrailingComma(expression.expressions[-1], expression)) {
+        if (rule.checkList &&
+                !hasTrailingComma(expression.expressions[-1], expression) &&
+                !lastExpressionIsEndOfExpression(expression.expressions[-1])
+        ) {
             addViolation(expression, 'List should contain trailing comma.')
         }
     }
@@ -77,5 +80,9 @@ class TrailingCommaAstVisitor extends AbstractAstVisitor {
                 outerExpression.lastColumnNumber
         )
         sourceLinesBetween.any { it.contains(',') }
+    }
+
+    private static boolean lastExpressionIsEndOfExpression(Expression lastExpression) {
+        lastExpression.lineNumber == lastExpression.lastLineNumber
     }
 }

--- a/src/test/groovy/org/codenarc/rule/convention/TrailingCommaRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/TrailingCommaRuleTest.groovy
@@ -143,6 +143,51 @@ class TrailingCommaRuleTest extends AbstractRuleTestCase {
         assertNoViolations(SOURCE)
     }
 
+    @Test
+    void testNoViolationForInlineListInAnAnnotation() {
+        final SOURCE = '''         
+         @ToString(
+            ignoreNulls = false,
+            excludes = ['bear', 'raccoon']
+         )
+         class TestClass{}
+        '''
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testNoViolationForMultiLineListInAnAnnotation() {
+        final SOURCE = '''         
+         @ToString(
+            ignoreNulls = false,
+            excludes = [
+                'bear', 
+                'raccoon',
+            ]
+         )
+         class TestClass{}
+        '''
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testSingleListViolationInAnAnnotation() {
+        final SOURCE = '''         
+         @ToString(
+            ignoreNulls = false,
+            excludes = [
+                'bear', 
+                'raccoon'
+            ]
+         )
+         class TestClass{}
+        '''
+
+        assertSingleViolation(SOURCE, 4, 'excludes = [', 'List should contain trailing comma.')
+    }
+
     protected Rule createRule() {
         new TrailingCommaRule()
     }


### PR DESCRIPTION
I was having false CodeNarc errors show up for the TrailingComma Rule with code similar to this:
```groovy
@ToString(
    ignoreNulls = false,
    excludes = ['bear', 'raccoon']
)
class TestClass{}
```

Digging through the code, the list was marked as starting with `excludes = [` and ending with `)` instead of ending with `]`. So when passing the expressions in to `sourceLinesBetween()`, the returned nodes would be `[']', ')']` (I trimmed the whitespace to make it easier to see). Luckily the lastExpression in these single line Lists has the same `lineNumber` and `lastLineNumber`. Awesome! Unfortunately that is not the same for Maps.

For List checks, I found that you don't actually need to check for the trailing comma. The following code was sufficient and all tests pass. However, I figured you wanted the consistency with the Map detections, and the same style does not work for maps unfortunately.
```groovy
 @Override
 void visitListExpression(ListExpression expression) {
     if (expression.expressions.isEmpty()) {
         return
     }
     if (rule.checkList && !lastExpressionIsEndOfExpression(expression.expressions[-1])
     ) {
         addViolation(expression, 'List should contain trailing comma.')
     }
 }
```