### PR TITLE
Add enhanced mode to CompareWithoutComparable

### DIFF
--- a/src/main/groovy/org/codenarc/rule/design/CompareToWithoutComparableRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/design/CompareToWithoutComparableRule.groovy
@@ -16,6 +16,7 @@
 package org.codenarc.rule.design
 
 import org.codehaus.groovy.ast.MethodNode
+import org.codehaus.groovy.control.Phases
 import org.codenarc.rule.AbstractAstVisitorRule
 import org.codenarc.rule.AbstractMethodVisitor
 import org.codenarc.util.AstUtil
@@ -31,6 +32,12 @@ class CompareToWithoutComparableRule extends AbstractAstVisitorRule {
     String name = 'CompareToWithoutComparable'
     int priority = 2
     Class astVisitorClass = CompareToWithoutComparableAstVisitor
+    boolean enhancedMode
+
+    @Override
+    int getCompilerPhase() {
+        enhancedMode ? Phases.CANONICALIZATION : super.compilerPhase
+    }
 }
 
 class CompareToWithoutComparableAstVisitor extends AbstractMethodVisitor {

--- a/src/site/apt/codenarc-rules-design.apt
+++ b/src/site/apt/codenarc-rules-design.apt
@@ -151,6 +151,10 @@ Design Rules  ("<rulesets/design.xml>")
   don't then you could possibly get an exception if the Groovy == operator is invoked on your object.
   This is an issue fixed in Groovy 1.8 but present in previous versions.
 
+  This rule has a single <<<enhancedMode>>> property which defaults to <<<false>>>. When set to <<<true>>>, this rule
+  will run in {{{./codenarc-enhanced-classpath-rules.html}enhanced mode}} and will not produce a violation when a class
+  implements <<<compareTo>>> and extends a class that itself implements <<<Comparable>>>.
+
   Here is an example of code that produces a violation:
 
 -------------------------------------------------------------------------------
@@ -161,8 +165,9 @@ Design Rules  ("<rulesets/design.xml>")
 
  Known limitations:
 
-  * This rule is not able to determine if the class extends a superclass that itself implements <<<Comparable>>>, or
-    if it implements an interface that extends <<<Comparable>>>. In those cases, this rule produces a false violation.
+  * When not running in enhanced mode, this rule is not able to determine if the class extends a superclass that itself
+    implements <<<Comparable>>>, or if it implements an interface that extends <<<Comparable>>>. In those cases, this
+    rule produces a false violation.
 
 
 * {ConstantsOnlyInterface} Rule


### PR DESCRIPTION
To avoid false positives when a superclass implements `Comparable`.

If you are happy with this we can take it to the next level in a separate PR by adding support for changing the default value of `enhancedMode` via a system property as suggested by me in #224.