### PR TITLE
removed SuppressWarnings that were not needed.

### DIFF
--- a/src/main/groovy/org/codenarc/CodeNarcRunner.groovy
+++ b/src/main/groovy/org/codenarc/CodeNarcRunner.groovy
@@ -60,6 +60,7 @@ class CodeNarcRunner {
      * </ol>
      * @returns the <code>Results</code> object containing the results of the CodeNarc analysis.
      */
+    @SuppressWarnings('Println')
     Results execute() {
         assert ruleSetFiles, 'The ruleSetFiles property must be set'
         assert sourceAnalyzer, 'The sourceAnalyzer property must be set to a valid SourceAnalayzer'

--- a/src/main/groovy/org/codenarc/report/InlineXmlReportWriter.groovy
+++ b/src/main/groovy/org/codenarc/report/InlineXmlReportWriter.groovy
@@ -24,7 +24,6 @@ import org.codenarc.rule.Violation
  *
  * @author Robin Bramley
  */
-@SuppressWarnings('UnnecessaryReturnKeyword')
 class InlineXmlReportWriter extends XmlReportWriter {
 
     //--------------------------------------------------------------------------
@@ -47,7 +46,6 @@ class InlineXmlReportWriter extends XmlReportWriter {
         // No-op as we have inline rule descriptions
     }
 
-    @SuppressWarnings('FactoryMethodName')
     private buildDescriptionElement(rule) {
         def description = this.getDescriptionForRule(rule)
         return { Description(XmlReportUtil.cdata(description)) }

--- a/src/main/groovy/org/codenarc/rule/basic/BrokenOddnessCheckRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/basic/BrokenOddnessCheckRule.groovy
@@ -34,27 +34,21 @@ class BrokenOddnessCheckRule extends AbstractAstVisitorRule {
 
 class BrokenOddnessCheckAstVisitor extends AbstractAstVisitor {
 
-    @SuppressWarnings('NestedBlockDepth')  // this code isn't that bad
     @Override
     void visitBinaryExpression(BinaryExpression expression) {
 
         if (AstUtil.isBinaryExpressionType(expression, '==')) {
-            if (AstUtil.isBinaryExpressionType(expression.leftExpression, '%')) {
-                if (AstUtil.isConstant(expression.rightExpression, 1)) {
-                    BinaryExpression modExp = expression.leftExpression
-                    if (AstUtil.isConstant(modExp.rightExpression, 2)) {
-                        def variable = modExp.leftExpression.text
-                        addViolation(expression, "The code uses '($variable % 2 == 1)' to check for oddness, which does not work for negative numbers. Use ($variable & 1 == 1) or ($variable % 2 != 0) instead")
-                    } 
+            if (AstUtil.isBinaryExpressionType(expression.leftExpression, '%') && AstUtil.isConstant(expression.rightExpression, 1)) {
+                BinaryExpression modExp = expression.leftExpression
+                if (AstUtil.isConstant(modExp.rightExpression, 2)) {
+                    def variable = modExp.leftExpression.text
+                    addViolation(expression, "The code uses '($variable % 2 == 1)' to check for oddness, which does not work for negative numbers. Use ($variable & 1 == 1) or ($variable % 2 != 0) instead")
                 }
-            } else if (AstUtil.isBinaryExpressionType(expression.rightExpression, '%')) {
-
-                if (AstUtil.isConstant(expression.leftExpression, 1)) {
-                    BinaryExpression modExp = expression.rightExpression
-                    if (AstUtil.isConstant(modExp.rightExpression, 2)) {
-                        def variable = modExp.leftExpression.text
-                        addViolation(expression, "The code uses '(1 == $variable % 2)' to check for oddness, which does not work for negative numbers. Use ($variable & 1 == 1) or ($variable % 2 != 0) instead")
-                    }
+            } else if (AstUtil.isBinaryExpressionType(expression.rightExpression, '%') && AstUtil.isConstant(expression.leftExpression, 1)) {
+                BinaryExpression modExp = expression.rightExpression
+                if (AstUtil.isConstant(modExp.rightExpression, 2)) {
+                    def variable = modExp.leftExpression.text
+                    addViolation(expression, "The code uses '(1 == $variable % 2)' to check for oddness, which does not work for negative numbers. Use ($variable & 1 == 1) or ($variable % 2 != 0) instead")
                 }
             }
         }

--- a/src/main/groovy/org/codenarc/rule/basic/DuplicateMapKeyRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/basic/DuplicateMapKeyRule.groovy
@@ -33,13 +33,12 @@ class DuplicateMapKeyRule extends AbstractAstVisitorRule {
 
 class DuplicateMapKeyAstVisitor extends AbstractAstVisitor {
     @Override
-    @SuppressWarnings('UnnecessaryCollectCall')
     void visitMapExpression(MapExpression expression) {
 
         if(isFirstVisit(expression)) {
             def a = expression.mapEntryExpressions
                     .findAll { it.keyExpression instanceof ConstantExpression }
-                    .collect { it.keyExpression }
+                    *.keyExpression
 
             a.inject([]) { result, it ->
                 if (result.contains(it.value)) {

--- a/src/main/groovy/org/codenarc/rule/concurrency/InconsistentPropertySynchronizationRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/concurrency/InconsistentPropertySynchronizationRule.groovy
@@ -96,15 +96,14 @@ class InconsistentPropertySynchronizationAstVisitor extends AbstractMethodVisito
         }
     }
 
-    @SuppressWarnings('CyclomaticComplexity')
     private void addViolationOnMismatch(List rawGetterNames, String setterName) {
         def getterNames = rawGetterNames*.toString() // force GString into strings
 
-        if (containsKey(synchronizedMethods, getterNames) && unsynchronizedMethods.containsKey(setterName)) {
+        if (isGetterSynchronizedAndSetterUnsychronized(getterNames, setterName)) {
             def getterName = getFirstValue(synchronizedMethods, getterNames).name
             MethodNode node = unsynchronizedMethods.get(setterName)
             addViolation(node, "The getter method $getterName is synchronized but the setter method $setterName is not")
-        } else if (containsKey(unsynchronizedMethods, getterNames) && synchronizedMethods.containsKey(setterName)) {
+        } else if (isGetterUnsynchronizedAndSetterSychronized(getterNames, setterName)) {
             def getterName = getFirstValue(unsynchronizedMethods, getterNames).name
             MethodNode node = unsynchronizedMethods.get(getterName)
             addViolation(node, "The setter method $setterName is synchronized but the getter method $getterName is not")
@@ -130,4 +129,13 @@ class InconsistentPropertySynchronizationAstVisitor extends AbstractMethodVisito
     private static MethodNode getFirstValue(Map<String, MethodNode> methodList, List<String> keys) {
         methodList.find { it.key in keys }.value
     }
+
+    private boolean isGetterSynchronizedAndSetterUnsychronized(List<String> getterNames, String setterName) {
+        containsKey(synchronizedMethods, getterNames) && unsynchronizedMethods.containsKey(setterName)
+    }
+
+    private boolean isGetterUnsynchronizedAndSetterSychronized(List<String> getterNames, String setterName) {
+        containsKey(unsynchronizedMethods, getterNames) && synchronizedMethods.containsKey(setterName)
+    }
+
 }

--- a/src/main/groovy/org/codenarc/rule/formatting/ClassJavadocRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/ClassJavadocRule.groovy
@@ -37,7 +37,6 @@ class ClassJavadocRule extends AbstractRule {
      * @param violations A list of Violations that may be added to. It can be an empty list
      */
     @Override
-    @SuppressWarnings('EmptyWhileStatement')
     void applyTo(SourceCode sourceCode, List violations) {
 
         def lines = sourceCode.getLines()

--- a/src/main/groovy/org/codenarc/rule/grails/GrailsDomainReservedSqlKeywordNameRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/grails/GrailsDomainReservedSqlKeywordNameRule.groovy
@@ -145,6 +145,7 @@ class GrailsDomainReservedSqlKeywordNameAstVisitor extends AbstractAstVisitor {
             assert expressions.every { it.type.name == String.name }
             transients = expressions*.value
         } catch (AssertionError e) {
+            // ignore exception
         }
     }
 

--- a/src/main/groovy/org/codenarc/rule/grails/GrailsMassAssignmentRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/grails/GrailsMassAssignmentRule.groovy
@@ -35,18 +35,15 @@ class GrailsMassAssignmentRule extends AbstractAstVisitorRule {
     Class astVisitorClass = GrailsMassAssignmentAstVisitor
 }
 
-@SuppressWarnings('NestedBlockDepth')
 class GrailsMassAssignmentAstVisitor extends AbstractAstVisitor {
 
     @Override
     void visitConstructorCallExpression(ConstructorCallExpression call) {
-        if (isFirstVisit(call)) {
-            if (call.arguments && call.arguments.expressions) {
-                def exp = call.arguments.expressions.first()
-                if (exp instanceof VariableExpression) {
-                    if (exp.variable == 'params') {
-                        addViolation(call, 'Restrict mass attribute assignment')
-                    }
+        if (isFirstVisit(call) && call.arguments && call.arguments.expressions) {
+            def exp = call.arguments.expressions.first()
+            if (exp instanceof VariableExpression) {
+                if (exp.variable == 'params') {
+                    addViolation(call, 'Restrict mass attribute assignment')
                 }
             }
         }
@@ -55,14 +52,15 @@ class GrailsMassAssignmentAstVisitor extends AbstractAstVisitor {
 
     @Override
     void visitBinaryExpression(BinaryExpression expression) {
-        if (isFirstVisit(expression)) {
-            if (expression.leftExpression instanceof PropertyExpression && !(expression.leftExpression instanceof AttributeExpression) ) {
-                if (expression.leftExpression.property.hasProperty('value') && expression.leftExpression.property.value == 'properties') {
-                    if (expression.rightExpression instanceof VariableExpression && expression.rightExpression.variable == 'params') {
-                        addViolation(expression, 'Restrict mass attribute assignment')
-                    }
-                }
-            }
+        if (isFirstVisit(expression) &&
+                expression.leftExpression instanceof PropertyExpression &&
+                !(expression.leftExpression instanceof AttributeExpression) &&
+                expression.leftExpression.property.hasProperty('value') &&
+                expression.leftExpression.property.value == 'properties' &&
+                expression.rightExpression instanceof VariableExpression &&
+                expression.rightExpression.variable == 'params'
+        ) {
+            addViolation(expression, 'Restrict mass attribute assignment')
         }
         super.visitBinaryExpression(expression)
 

--- a/src/main/groovy/org/codenarc/rule/imports/ImportFromSamePackageRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/imports/ImportFromSamePackageRule.groovy
@@ -24,7 +24,6 @@ import org.codenarc.util.ImportUtil
  *
  * @author Chris Mair
   */
-@SuppressWarnings('DuplicateLiteral')
 class ImportFromSamePackageRule extends AbstractRule {
     String name = 'ImportFromSamePackage'
     int priority = 3

--- a/src/main/groovy/org/codenarc/rule/junit/UseAssertEqualsInsteadOfAssertTrueRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/junit/UseAssertEqualsInsteadOfAssertTrueRule.groovy
@@ -36,7 +36,6 @@ class UseAssertEqualsInsteadOfAssertTrueRule extends AbstractAstVisitorRule {
 
 class UseAssertEqualsInsteadOfAssertTrueAstVisitor extends AbstractMethodCallExpressionVisitor {
 
-    @SuppressWarnings('DuplicateLiteral')
     void visitMethodCallExpression(MethodCallExpression call) {
 
         List args = AstUtil.getMethodArguments(call)

--- a/src/main/groovy/org/codenarc/rule/junit/UseAssertFalseInsteadOfNegationRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/junit/UseAssertFalseInsteadOfNegationRule.groovy
@@ -35,7 +35,6 @@ class UseAssertFalseInsteadOfNegationRule extends AbstractAstVisitorRule {
 
 class UseAssertFalseInsteadOfNegationAstVisitor extends AbstractMethodCallExpressionVisitor {
 
-    @SuppressWarnings('DuplicateLiteral')
     void visitMethodCallExpression(MethodCallExpression call) {
 
         List args = AstUtil.getMethodArguments(call)

--- a/src/main/groovy/org/codenarc/rule/junit/UseAssertTrueInsteadOfNegationRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/junit/UseAssertTrueInsteadOfNegationRule.groovy
@@ -35,7 +35,6 @@ class UseAssertTrueInsteadOfNegationRule extends AbstractAstVisitorRule {
 
 class UseAssertTrueInsteadOfNegationAstVisitor extends AbstractMethodCallExpressionVisitor {
 
-    @SuppressWarnings('DuplicateLiteral')
     void visitMethodCallExpression(MethodCallExpression call) {
 
         List args = AstUtil.getMethodArguments(call)

--- a/src/main/groovy/org/codenarc/rule/logging/PrintlnRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/logging/PrintlnRule.groovy
@@ -56,7 +56,6 @@ class PrintlnAstVisitor extends AbstractAstVisitor  {
         printlnClosureDefined = false
     }
 
-    @SuppressWarnings('DuplicateLiteral')
     void visitMethodCallExpression(MethodCallExpression methodCall) {
         if (printlnMethodDefined || printlnClosureDefined) {
             return

--- a/src/main/groovy/org/codenarc/rule/naming/ObjectOverrideMisspelledMethodNameRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/naming/ObjectOverrideMisspelledMethodNameRule.groovy
@@ -35,7 +35,6 @@ class ObjectOverrideMisspelledMethodNameRule extends AbstractAstVisitorRule {
 class ObjectOverrideMisspelledMethodNameAstVisitor extends AbstractMethodVisitor {
 
     @Override
-    @SuppressWarnings('DuplicateLiteral')
     void visitMethod(MethodNode node) {
         checkForExactMethodName(node, 'equal', ['Object'], 'equals')
         checkForMethodNameWithIncorrectCase(node, 'equals', ['Object'])

--- a/src/main/groovy/org/codenarc/rule/size/AbstractMethodMetricAstVisitor.groovy
+++ b/src/main/groovy/org/codenarc/rule/size/AbstractMethodMetricAstVisitor.groovy
@@ -37,7 +37,6 @@ import org.gmetrics.metric.Metric
  * @author Chris Mair
  * @author Hamlet D'Arcy
   */
-@SuppressWarnings('DuplicateLiteral')
 abstract class AbstractMethodMetricAstVisitor extends AbstractAstVisitor  {
 
     protected Metric metric

--- a/src/main/groovy/org/codenarc/rule/unused/UnusedPrivateMethodRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/unused/UnusedPrivateMethodRule.groovy
@@ -83,7 +83,6 @@ class UnusedPrivateMethodRule extends AbstractSharedAstVisitorRule {
     }
 }
 
-@SuppressWarnings('DuplicateLiteral')
 class UnusedPrivateMethodAstVisitor extends AbstractAstVisitor {
 
     private final Map<String, MethodNode> unusedPrivateMethods

--- a/src/main/groovy/org/codenarc/rule/unused/UnusedVariableRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/unused/UnusedVariableRule.groovy
@@ -53,7 +53,7 @@ class UnusedVariableRule extends AbstractAstVisitorRule {
                 collector.visitClass(it)
             }
             def anonymousReferences = collector.references
-            
+
             ast.classes.each { classNode ->
 
                 if (shouldApplyThisRuleTo(classNode)) {
@@ -151,10 +151,9 @@ class UnusedVariableAstVisitor extends AbstractAstVisitor  {
         super.visitMethodCallExpression(call)
     }
 
-    @SuppressWarnings('NestedForLoop')
     private void markVariableAsReferenced(String varName, VariableExpression varExpression) {
-        for(blockVariables in variablesByBlockScope) {
-            for(var in blockVariables.keySet()) {
+        variablesByBlockScope.each { blockVariables ->
+            blockVariables.keySet().each { var ->
                 if (var.name == varName && var != varExpression) {
                     blockVariables[var] = true
                     return

--- a/src/main/groovy/org/codenarc/ruleset/XmlReaderRuleSet.groovy
+++ b/src/main/groovy/org/codenarc/ruleset/XmlReaderRuleSet.groovy
@@ -29,7 +29,6 @@ import javax.xml.validation.SchemaFactory
  *
  * @author Chris Mair
   */
-@SuppressWarnings('DuplicateLiteral')
 class XmlReaderRuleSet implements RuleSet {
 
     // W3C_XML_SCHEMA_NS_URI constant is not defined in older versions of javax.xml.XMLConstants 

--- a/src/main/groovy/org/codenarc/util/WildcardPattern.groovy
+++ b/src/main/groovy/org/codenarc/util/WildcardPattern.groovy
@@ -93,7 +93,6 @@ class WildcardPattern {
      *
      * @throws AssertionError - if the stringWithWildcards is null
      */
-    @SuppressWarnings('DuplicateLiteral')
     private static String convertStringWithWildcardsToRegex(String stringWithWildcards) {
         assert stringWithWildcards != null
 

--- a/src/test/resources/RunCodeNarcAgainstProjectSourceCode.properties
+++ b/src/test/resources/RunCodeNarcAgainstProjectSourceCode.properties
@@ -11,7 +11,7 @@ MisorderedStaticImports.doNotApplyToFileNames = *Test.groovy, *TestCase.groovy
 NestedBlockDepth.maxNestedBlockDepth = 3
 NestedBlockDepth.doNotApplyToClassNames = *ReportWriter, RuleSetBuilderTest
 
-Println.doNotApplyToClassNames = TextReportWriter, *Test, *TestCase, CodeNarcRunner, Generate*
+Println.doNotApplyToClassNames = TextReportWriter, *Test, *TestCase, Generate*
 
 PrivateFieldCouldBeFinal.doNotApplyToClassNames = *Test
 


### PR DESCRIPTION
In some cases the SuppressWarning was simply removed. For example, `EmptyWhileStatement` was being suppressed, but the while statement was not actually empty.

Other cases, the code needed small refactoring. For Example `NestedBlockDepth` warnings.