### PR TITLE
Use earlier compiler phase in MissingOverrideAnnotation rule

### DIFF
--- a/src/main/groovy/org/codenarc/rule/enhanced/MissingOverrideAnnotationRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/enhanced/MissingOverrideAnnotationRule.groovy
@@ -32,7 +32,7 @@ class MissingOverrideAnnotationRule extends AbstractAstVisitorRule {
     String name = 'MissingOverrideAnnotation'
     int priority = 3
     Class astVisitorClass = MissingOverrideAnnotationAstVisitor
-    int compilerPhase = Phases.CANONICALIZATION
+    int compilerPhase = Phases.SEMANTIC_ANALYSIS
 }
 
 class MissingOverrideAnnotationAstVisitor extends AbstractAstVisitor {

--- a/src/test/groovy/org/codenarc/rule/enhanced/MissingOverrideAnnotationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/enhanced/MissingOverrideAnnotationRuleTest.groovy
@@ -31,7 +31,7 @@ class MissingOverrideAnnotationRuleTest extends AbstractRuleTestCase {
     void testRuleProperties() {
         assert rule.priority == 3
         assert rule.name == 'MissingOverrideAnnotation'
-        assert rule.compilerPhase == Phases.CANONICALIZATION
+        assert rule.compilerPhase == Phases.SEMANTIC_ANALYSIS
     }
 
     @Test


### PR DESCRIPTION
There is no need to use `CANONICALIZATION` in that rule, `SEMANTIC_ANALYSIS` will suffice, and using an earlier phase will save time by not having to perform another compilation phase on the analysed code.