### PR TITLE
Update to ignore semicolons in multiline comments

### DIFF
--- a/src/main/groovy/org/codenarc/rule/formatting/BlankLineBeforePackageRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/BlankLineBeforePackageRule.groovy
@@ -18,10 +18,11 @@ package org.codenarc.rule.formatting
 import org.codehaus.groovy.ast.PackageNode
 import org.codenarc.rule.AbstractRule
 import org.codenarc.source.SourceCode
+import org.codenarc.util.MultilineCommentChecker
 
 /**
  * Makes sure there are no blank lines before the package declaration of a source code file.
- * 
+ *
  * @author Joe Sondow
  */
 class BlankLineBeforePackageRule extends AbstractRule {
@@ -34,8 +35,12 @@ class BlankLineBeforePackageRule extends AbstractRule {
 
         PackageNode packageNode = sourceCode.ast?.package
         if (packageNode) {
+            MultilineCommentChecker multilineCommentChecker = new MultilineCommentChecker()
+
             for (int index = 0; index < packageNode.lineNumber; index++) {
-                if (sourceCode.line(index).isEmpty()) {
+                multilineCommentChecker.processLine(sourceCode.line(index))
+
+                if (sourceCode.line(index).isEmpty() && !multilineCommentChecker.inMultilineComment) {
                     violations.add(createViolation(index, sourceCode.line(index),
                         "Blank line precedes package declaration in file $sourceCode.name"))
                 }

--- a/src/main/groovy/org/codenarc/rule/unnecessary/UnnecessarySemicolonRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/unnecessary/UnnecessarySemicolonRule.groovy
@@ -87,6 +87,14 @@ class UnnecessarySemicolonRule extends AbstractAstVisitorRule {
 
     private boolean isInsideMultilineComment(String line, boolean insideMultilineComment) {
         if (line.matches(startMultilineCommentPattern)) {
+            if (line.matches(endMultilineCommentPattern)) {
+                int startIndex = line.indexOf('/*')
+                int endIndex = line.indexOf('*/')
+
+                if (endIndex >  startIndex) {
+                    return false
+                }
+            }
             return true
         } else if (line.matches(endMultilineCommentPattern)) {
             return false

--- a/src/main/groovy/org/codenarc/util/MultilineCommentChecker.groovy
+++ b/src/main/groovy/org/codenarc/util/MultilineCommentChecker.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codenarc.util
+
+/**
+ * A class that is used to hold the state of a the presence of multiline comments.
+ *
+ * When processing files for violations, not all violations apply to comments. This class provides a simple way to
+ * process each line of code and determine if the current line exists inside of a multiline comment.
+ *
+ * @author Russell Sanborn
+ */
+class MultilineCommentChecker {
+    static final String START_MULTILINE_COMMENT = '/*'
+    static final String END_MULTILINE_COMMENT = '*/'
+    static final String START_MULTILINE_COMMENT_PATTERN = '.*/\\*.*'
+    static final String END_MULTILINE_COMMENT_PATTERN = '.*\\*/.*'
+
+    boolean inMultilineComment
+
+    MultilineCommentChecker() {
+        inMultilineComment = false
+    }
+
+    /**
+     * Processes a line of code sets the inMultilineComment state based on the status of the current line.
+     *
+     * @param line the current line to be checked
+     */
+    void processLine(String line) {
+        if (line.matches(START_MULTILINE_COMMENT_PATTERN) && line.matches(END_MULTILINE_COMMENT_PATTERN)) {
+            int startIndex = line.indexOf(START_MULTILINE_COMMENT)
+            int endIndex = line.indexOf(END_MULTILINE_COMMENT)
+
+            inMultilineComment = (endIndex < startIndex)
+        } else if (line.matches(START_MULTILINE_COMMENT_PATTERN)) {
+            inMultilineComment = true
+        } else if (line.matches(END_MULTILINE_COMMENT_PATTERN)) {
+            inMultilineComment = false
+        }
+    }
+}

--- a/src/main/groovy/org/codenarc/util/MultilineCommentChecker.groovy
+++ b/src/main/groovy/org/codenarc/util/MultilineCommentChecker.groovy
@@ -24,12 +24,12 @@ package org.codenarc.util
  * @author Russell Sanborn
  */
 class MultilineCommentChecker {
-    static final String START_MULTILINE_COMMENT = '/*'
-    static final String END_MULTILINE_COMMENT = '*/'
-    static final String START_MULTILINE_COMMENT_PATTERN = '.*/\\*.*'
-    static final String END_MULTILINE_COMMENT_PATTERN = '.*\\*/.*'
+    private static final String START_MULTILINE_COMMENT = '/*'
+    private static final String END_MULTILINE_COMMENT = '*/'
+    private static final String START_MULTILINE_COMMENT_PATTERN = '.*/\\*.*'
+    private static final String END_MULTILINE_COMMENT_PATTERN = '.*\\*/.*'
 
-    boolean inMultilineComment
+    protected boolean inMultilineComment
 
     MultilineCommentChecker() {
         inMultilineComment = false

--- a/src/test/groovy/org/codenarc/rule/formatting/BlankLineBeforePackageRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/BlankLineBeforePackageRuleTest.groovy
@@ -107,6 +107,26 @@ class BlankLineBeforePackageRuleTest extends AbstractRuleTestCase {
         assertSingleViolation(SOURCE, 1, '', 'Blank line precedes package declaration in file null')
     }
 
+    @Test
+    void testSuccessScenarioWithBlankLineInsideCommentBlock() {
+        final SOURCE = '''\
+            /* 
+             Comment block
+             
+             has a blank line
+             */
+            package org.codenarc
+            
+            class MyClass {
+
+                    def go() { /* ... */ }
+                    def goSomewhere() { /* ... */ }
+
+            }
+        '''
+        assertNoViolations(SOURCE)
+    }
+
     @Override
     protected Rule createRule() {
         new BlankLineBeforePackageRule()

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessarySemicolonRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessarySemicolonRuleTest.groovy
@@ -164,6 +164,15 @@ class UnnecessarySemicolonRuleTest extends AbstractRuleTestCase {
         assert !manuallyApplyRule(SOURCE)
     }
 
+    @Test
+    void testMultilineCommentWrittenAsASingleLine() {
+        final SOURCE = '''
+        /* no semi colon here */
+        println("raccoon");
+        '''
+        assertSingleViolation(SOURCE, 3, 'println("raccoon");', 'Semi-colons as line endings can be removed safely')
+    }
+
     @Override
     protected Rule createRule() {
         new UnnecessarySemicolonRule()

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessarySemicolonRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessarySemicolonRuleTest.groovy
@@ -144,6 +144,26 @@ class UnnecessarySemicolonRuleTest extends AbstractRuleTestCase {
         assertSingleViolation(SOURCE, 4, 'return 1;', 'Semi-colons as line endings can be removed safely')
     }
 
+    @Test
+    void testSemiColonInMultilineCommentsWithoutLeadingAsterisk() {
+        final SOURCE = '''
+        /*
+         (the "License");
+         (the "License");
+         (the "License");
+         you may not use this file except in compliance with the License. 
+         */
+         
+         /*
+          have a multiline comment
+          */ /*  and start a new multiline comment on the previous ending line;  
+          though i doubt this is a good thing
+          */
+         
+        '''
+        assert !manuallyApplyRule(SOURCE)
+    }
+
     @Override
     protected Rule createRule() {
         new UnnecessarySemicolonRule()

--- a/src/test/groovy/org/codenarc/util/MultilineCommentCheckerTest.groovy
+++ b/src/test/groovy/org/codenarc/util/MultilineCommentCheckerTest.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codenarc.util
+
+import org.codenarc.test.AbstractTestCase
+import org.junit.Test
+
+/**
+ * Tests for MultilineCommentChecker
+ *
+ * @author Russell Sanborn
+ */
+class MultilineCommentCheckerTest extends AbstractTestCase {
+
+    @Test
+    void testInitialStateFromConstructor() {
+        MultilineCommentChecker multilineCommentChecker = new MultilineCommentChecker()
+        assert !multilineCommentChecker.inMultilineComment
+    }
+
+    @Test
+    void testProcessingLines() {
+        MultilineCommentChecker multilineCommentChecker = new MultilineCommentChecker()
+
+        multilineCommentChecker.processLine('not a multiline comment')
+        assert !multilineCommentChecker.inMultilineComment
+
+        multilineCommentChecker.processLine('/* start multiline comment')
+        assert multilineCommentChecker.inMultilineComment
+
+        multilineCommentChecker.processLine('still inside multiline comment')
+        assert multilineCommentChecker.inMultilineComment
+
+        multilineCommentChecker.processLine('close multiline comment */')
+        assert !multilineCommentChecker.inMultilineComment
+
+        multilineCommentChecker.processLine('still not a multiline comment')
+        assert !multilineCommentChecker.inMultilineComment
+
+        multilineCommentChecker.processLine('/* single line comment block is not a multiline comment */')
+        assert !multilineCommentChecker.inMultilineComment
+    }
+
+}


### PR DESCRIPTION
According to issue #236 multiline comments that do not have a leading asterisk were throwing a false positive. I updated the logic to contain a simple boolean that will keep track of whether the line is inside of a comment block or not.