### PR TITLE
Fix false positive when an annotation has a brace

### DIFF
--- a/src/main/groovy/org/codenarc/rule/formatting/SpaceAfterOpeningBraceRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/SpaceAfterOpeningBraceRule.groovy
@@ -61,7 +61,7 @@ class SpaceAfterOpeningBraceAstVisitor extends AbstractSpaceAroundBraceAstVisito
         isFirstVisit(node.code)   // Register the code block so that it will be ignored in visitBlockStatement()
         def line = sourceLineOrEmpty(node)
         int lastOpen = line.lastIndexOf('{')
-        if (lastOpen < line.length() - 1 && line[lastOpen + 1] =~ /\S/ && checkIsEmptyBlock(line, lastOpen + 2)) {
+        if (lastOpen < line.length() - 1 && !line[lastOpen + 1].isAllWhitespace() && checkIsEmptyBlock(line, lastOpen + 2)) {
             addOpeningBraceViolation(node, 'block')
         }
         super.visitConstructor(node)

--- a/src/main/groovy/org/codenarc/rule/formatting/SpaceAfterOpeningBraceRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/SpaceAfterOpeningBraceRule.groovy
@@ -60,7 +60,8 @@ class SpaceAfterOpeningBraceAstVisitor extends AbstractSpaceAroundBraceAstVisito
 
         isFirstVisit(node.code)   // Register the code block so that it will be ignored in visitBlockStatement()
         def line = sourceLineOrEmpty(node)
-        if (line =~ /\{\S/ && checkIsEmptyBlock(line, line.indexOf('{') + 2)) {
+        int lastOpen = line.lastIndexOf('{')
+        if (lastOpen < line.length() - 1 && line[lastOpen + 1] =~ /\S/ && checkIsEmptyBlock(line, lastOpen + 2)) {
             addOpeningBraceViolation(node, 'block')
         }
         super.visitConstructor(node)

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterOpeningBraceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterOpeningBraceRuleTest.groovy
@@ -54,6 +54,9 @@ class SpaceAfterOpeningBraceRuleTest extends AbstractRuleTestCase {
                 MyClass() {
                     this(classNames)
                 }
+                MyClass(String s) { }
+                MyClass(@Annotation('${prop}') String s) {
+                }
             }
             interface MyInterface { }
             enum MyEnum { OK, BAD }
@@ -92,6 +95,8 @@ class SpaceAfterOpeningBraceRuleTest extends AbstractRuleTestCase {
                     while (count > this."maxPriority${priority}Violations") {}
                 }
                 void doStuff2() {}
+                MyClass() {}
+                MyClass(@Annotation('${prop}') String s) {}
             }
             interface MyInterface2 {}
         '''


### PR DESCRIPTION
If a constructor contained a brace, `SpaceAfterOpeningBraceRule` would report a false positive:

```
class MyClass {
  MyClass(@Value('${property}') String property) {

  }
}
```

It is not uncommon for Spring projects that use this mechanism to load properties into the construction of an object.