### PR TITLE
Remove "clean" task from suggested gradle test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ For projects built using Gradle or Maven, **CodeNarc** is available from the Mav
 When contributing to CodeNarc, run the following command to test on your local machine.
 
 ```bash
-./gradlew clean check
+./gradlew check
 ```


### PR DESCRIPTION
Thanks to @erdi for suggesting this be removed based on the link they provided:
https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks