### PR TITLE
Use GenericAbstractRuleTestCase as a base for all rule tests cases

### DIFF
--- a/src/test/groovy/org/codenarc/rule/AbstractAstVisitorRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/AbstractAstVisitorRuleTest.groovy
@@ -15,12 +15,12 @@
  */
 package org.codenarc.rule
 
+import static org.codenarc.test.TestUtil.shouldFailWithMessageContaining
+import static org.junit.Assert.assertFalse
+
 import org.codehaus.groovy.ast.ClassNode
 import org.codenarc.util.WildcardPattern
 import org.junit.Test
-
-import static org.codenarc.test.TestUtil.shouldFailWithMessageContaining
-import static org.junit.Assert.assertFalse
 
 /**
  * Tests for AbstractAstVisitorRule
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertFalse
  * @author Chris Mair
  * @author Hamlet D'Arcy
  */
-class AbstractAstVisitorRuleTest extends AbstractRuleTestCase {
+class AbstractAstVisitorRuleTest extends GenericAbstractRuleTestCase<AbstractAstVisitorRule> {
     private static final SOURCE = '''
         class MyClass {
             int value
@@ -227,7 +227,7 @@ class AbstractAstVisitorRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected AbstractAstVisitorRule createRule() {
         new FakeAstVisitorRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/AbstractClassReferenceRuleTestCase.groovy
+++ b/src/test/groovy/org/codenarc/rule/AbstractClassReferenceRuleTestCase.groovy
@@ -22,7 +22,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-abstract class AbstractClassReferenceRuleTestCase extends AbstractRuleTestCase {
+abstract class AbstractClassReferenceRuleTestCase<T extends Rule> extends GenericAbstractRuleTestCase<T> {
 
     /**
      * @return the name of the class to check for
@@ -33,12 +33,6 @@ abstract class AbstractClassReferenceRuleTestCase extends AbstractRuleTestCase {
     protected String getViolationMessage() {
         "Found reference to ${getClassName()}"
     }
-
-    /**
-     * @return an initialized rule instance
-     */
-    @Override
-    protected abstract Rule createRule()
 
     //------------------------------------------------------------------------------------
     // Common Tests

--- a/src/test/groovy/org/codenarc/rule/AbstractRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/AbstractRuleTest.groovy
@@ -15,21 +15,21 @@
  */
 package org.codenarc.rule
 
+import static org.codenarc.test.TestUtil.assertContainsAll
+import static org.codenarc.test.TestUtil.shouldFailWithMessageContaining
+
 import org.codehaus.groovy.control.Phases
 import org.codenarc.source.SourceCode
 import org.codenarc.source.SourceString
 import org.junit.Before
 import org.junit.Test
 
-import static org.codenarc.test.TestUtil.assertContainsAll
-import static org.codenarc.test.TestUtil.shouldFailWithMessageContaining
-
 /**
  * Tests for the AbstractRule class
  *
  * @author Chris Mair
  */
-class AbstractRuleTest extends AbstractRuleTestCase {
+class AbstractRuleTest extends GenericAbstractRuleTestCase<AbstractRule> {
 
     private static final NAME = 'Rule123'
     private static final PRIORITY = 2
@@ -314,7 +314,7 @@ class AbstractRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected AbstractRule createRule() {
         new FakePathRule(name:NAME, priority:PRIORITY)
     }
 

--- a/src/test/groovy/org/codenarc/rule/ClassResolutionTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/ClassResolutionTest.groovy
@@ -21,7 +21,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ClassResolutionTest extends AbstractRuleTestCase {
+class ClassResolutionTest extends GenericAbstractRuleTestCase<Rule> {
 
     @Test
     void testGrabError() {

--- a/src/test/groovy/org/codenarc/rule/basic/AssertWithinFinallyBlockRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/AssertWithinFinallyBlockRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class AssertWithinFinallyBlockRuleTest extends AbstractRuleTestCase {
+class AssertWithinFinallyBlockRuleTest extends GenericAbstractRuleTestCase<AssertWithinFinallyBlockRule> {
 
     @Test
     void testRuleProperties() {
@@ -136,7 +135,7 @@ class AssertWithinFinallyBlockRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected AssertWithinFinallyBlockRule createRule() {
         new AssertWithinFinallyBlockRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/basic/AssignmentInConditionalRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/AssignmentInConditionalRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author 'Hamlet D'Arcy'
  * @author Chris Mair
  */
-class AssignmentInConditionalRuleTest extends AbstractRuleTestCase {
+class AssignmentInConditionalRuleTest extends GenericAbstractRuleTestCase<AssignmentInConditionalRule> {
 
     private static final VIOLATION_MESSAGE = 'Assignment used as conditional value, which always results in true. Use the == operator instead'
 
@@ -115,7 +114,7 @@ class AssignmentInConditionalRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected AssignmentInConditionalRule createRule() {
         new AssignmentInConditionalRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/BigDecimalInstantiationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/BigDecimalInstantiationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class BigDecimalInstantiationRuleTest extends AbstractRuleTestCase {
+class BigDecimalInstantiationRuleTest extends GenericAbstractRuleTestCase<BigDecimalInstantiationRule> {
 
     @Test
     void testRuleProperties() {
@@ -148,7 +147,7 @@ class BigDecimalInstantiationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected BigDecimalInstantiationRule createRule() {
         new BigDecimalInstantiationRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/basic/BitwiseOperatorInConditionalRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/BitwiseOperatorInConditionalRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Jeff Beck
  */
-class BitwiseOperatorInConditionalRuleTest extends AbstractRuleTestCase {
+class BitwiseOperatorInConditionalRuleTest extends GenericAbstractRuleTestCase<BitwiseOperatorInConditionalRule> {
 
     @Test
     void testRuleProperties() {
@@ -236,7 +235,7 @@ class BitwiseOperatorInConditionalRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected BitwiseOperatorInConditionalRule createRule() {
         new BitwiseOperatorInConditionalRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/BooleanGetBooleanRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/BooleanGetBooleanRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class BooleanGetBooleanRuleTest extends AbstractRuleTestCase {
+class BooleanGetBooleanRuleTest extends GenericAbstractRuleTestCase<BooleanGetBooleanRule> {
 
     @Test
     void testRuleProperties() {
@@ -50,7 +49,7 @@ class BooleanGetBooleanRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected BooleanGetBooleanRule createRule() {
         new BooleanGetBooleanRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/BrokenNullCheckRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/BrokenNullCheckRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class BrokenNullCheckRuleTest extends AbstractRuleTestCase {
+class BrokenNullCheckRuleTest extends GenericAbstractRuleTestCase<BrokenNullCheckRule> {
 
     @Test
     void testRuleProperties() {
@@ -96,7 +95,7 @@ class BrokenNullCheckRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected BrokenNullCheckRule createRule() {
         new BrokenNullCheckRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/BrokenOddnessCheckRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/BrokenOddnessCheckRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author 'Hamlet D'Arcy'
  */
-class BrokenOddnessCheckRuleTest extends AbstractRuleTestCase {
+class BrokenOddnessCheckRuleTest extends GenericAbstractRuleTestCase<BrokenOddnessCheckRule> {
 
     @Test
     void testRuleProperties() {
@@ -66,7 +65,7 @@ class BrokenOddnessCheckRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected BrokenOddnessCheckRule createRule() {
         new BrokenOddnessCheckRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/ClassForNameRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/ClassForNameRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ClassForNameRuleTest extends AbstractRuleTestCase {
+class ClassForNameRuleTest extends GenericAbstractRuleTestCase<ClassForNameRule> {
 
     @Test
     void testRuleProperties() {
@@ -54,7 +53,7 @@ class ClassForNameRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ClassForNameRule createRule() {
         new ClassForNameRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/ComparisonOfTwoConstantsRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/ComparisonOfTwoConstantsRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris mair
  */
-class ComparisonOfTwoConstantsRuleTest extends AbstractRuleTestCase {
+class ComparisonOfTwoConstantsRuleTest extends GenericAbstractRuleTestCase<ComparisonOfTwoConstantsRule> {
 
     private static final MESSAGE = 'Comparing two constants or constant literals'
 
@@ -122,7 +121,7 @@ class ComparisonOfTwoConstantsRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ComparisonOfTwoConstantsRule createRule() {
         new ComparisonOfTwoConstantsRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/ComparisonWithSelfRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/ComparisonWithSelfRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris mair
  */
-class ComparisonWithSelfRuleTest extends AbstractRuleTestCase {
+class ComparisonWithSelfRuleTest extends GenericAbstractRuleTestCase<ComparisonWithSelfRule> {
 
     private static final MESSAGE = 'Comparing an object to itself'
 
@@ -112,7 +111,7 @@ class ComparisonWithSelfRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ComparisonWithSelfRule createRule() {
         new ComparisonWithSelfRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/ConstantAssertExpressionRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/ConstantAssertExpressionRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class ConstantAssertExpressionRuleTest extends AbstractRuleTestCase {
+class ConstantAssertExpressionRuleTest extends GenericAbstractRuleTestCase<ConstantAssertExpressionRule> {
 
     @Test
     void testRuleProperties() {
@@ -123,7 +122,7 @@ class ConstantAssertExpressionRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ConstantAssertExpressionRule createRule() {
         new ConstantAssertExpressionRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/basic/ConstantIfExpressionRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/ConstantIfExpressionRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class ConstantIfExpressionRuleTest extends AbstractRuleTestCase {
+class ConstantIfExpressionRuleTest extends GenericAbstractRuleTestCase<ConstantIfExpressionRule> {
 
     @Test
     void testRuleProperties() {
@@ -106,7 +105,7 @@ class ConstantIfExpressionRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ConstantIfExpressionRule createRule() {
         new ConstantIfExpressionRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/basic/ConstantTernaryExpressionRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/ConstantTernaryExpressionRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -26,7 +25,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class ConstantTernaryExpressionRuleTest extends AbstractRuleTestCase {
+class ConstantTernaryExpressionRuleTest extends GenericAbstractRuleTestCase<ConstantTernaryExpressionRule> {
 
     @Test
     void testRuleProperties() {
@@ -111,7 +110,7 @@ class ConstantTernaryExpressionRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ConstantTernaryExpressionRule createRule() {
         new ConstantTernaryExpressionRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/basic/ConstantTernaryExpressionRule_ElvisTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/ConstantTernaryExpressionRule_ElvisTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -26,7 +25,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class ConstantTernaryExpressionRule_ElvisTest extends AbstractRuleTestCase {
+class ConstantTernaryExpressionRule_ElvisTest extends GenericAbstractRuleTestCase<ConstantTernaryExpressionRule> {
 
     @Test
     void testApplyTo_True_IsAViolation() {
@@ -105,7 +104,7 @@ class ConstantTernaryExpressionRule_ElvisTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ConstantTernaryExpressionRule createRule() {
         new ConstantTernaryExpressionRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/basic/DeadCodeRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/DeadCodeRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class DeadCodeRuleTest extends AbstractRuleTestCase {
+class DeadCodeRuleTest extends GenericAbstractRuleTestCase<DeadCodeRule> {
 
     @Test
     void testRuleProperties() {
@@ -119,7 +118,7 @@ class DeadCodeRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected DeadCodeRule createRule() {
         new DeadCodeRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/DoubleNegativeRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/DoubleNegativeRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class DoubleNegativeRuleTest extends AbstractRuleTestCase {
+class DoubleNegativeRuleTest extends GenericAbstractRuleTestCase<DoubleNegativeRule> {
 
     @Test
     void testRuleProperties() {
@@ -52,7 +51,7 @@ class DoubleNegativeRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected DoubleNegativeRule createRule() {
         new DoubleNegativeRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/DuplicateCaseStatementRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/DuplicateCaseStatementRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class DuplicateCaseStatementRuleTest extends AbstractRuleTestCase {
+class DuplicateCaseStatementRuleTest extends GenericAbstractRuleTestCase<DuplicateCaseStatementRule> {
 
     @Test
     void testRuleProperties() {
@@ -81,7 +80,7 @@ class DuplicateCaseStatementRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected DuplicateCaseStatementRule createRule() {
         new DuplicateCaseStatementRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/basic/DuplicateMapKeyRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/DuplicateMapKeyRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author '?ukasz Indykiewicz'
  */
-class DuplicateMapKeyRuleTest extends AbstractRuleTestCase {
+class DuplicateMapKeyRuleTest extends GenericAbstractRuleTestCase<DuplicateMapKeyRule> {
 
     @Test
     void testRuleProperties() {
@@ -93,7 +92,7 @@ class DuplicateMapKeyRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected DuplicateMapKeyRule createRule() {
         new DuplicateMapKeyRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/DuplicateSetValueRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/DuplicateSetValueRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class DuplicateSetValueRuleTest extends AbstractRuleTestCase {
+class DuplicateSetValueRuleTest extends GenericAbstractRuleTestCase<DuplicateSetValueRule> {
 
     @Test
     void testRuleProperties() {
@@ -83,7 +82,7 @@ class DuplicateSetValueRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected DuplicateSetValueRule createRule() {
         new DuplicateSetValueRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/EmptyCatchBlockRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/EmptyCatchBlockRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class EmptyCatchBlockRuleTest extends AbstractRuleTestCase {
+class EmptyCatchBlockRuleTest extends GenericAbstractRuleTestCase<EmptyCatchBlockRule> {
 
     @Test
     void testRuleProperties() {
@@ -108,7 +107,7 @@ class EmptyCatchBlockRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected EmptyCatchBlockRule createRule() {
         new EmptyCatchBlockRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/basic/EmptyClassRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/EmptyClassRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Artur Gajowy
  */
-class EmptyClassRuleTest extends AbstractRuleTestCase {
+class EmptyClassRuleTest extends GenericAbstractRuleTestCase<EmptyClassRule> {
 
     def skipTestThatUnrelatedCodeHasNoViolations
 
@@ -175,7 +174,7 @@ class EmptyClassRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected EmptyClassRule createRule() {
         new EmptyClassRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/EmptyElseBlockRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/EmptyElseBlockRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class EmptyElseBlockRuleTest extends AbstractRuleTestCase {
+class EmptyElseBlockRuleTest extends GenericAbstractRuleTestCase<EmptyElseBlockRule> {
 
     @Test
     void testRuleProperties() {
@@ -82,7 +81,7 @@ class EmptyElseBlockRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected EmptyElseBlockRule createRule() {
         new EmptyElseBlockRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/basic/EmptyFinallyBlockRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/EmptyFinallyBlockRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class EmptyFinallyBlockRuleTest extends AbstractRuleTestCase {
+class EmptyFinallyBlockRuleTest extends GenericAbstractRuleTestCase<EmptyFinallyBlockRule> {
 
     @Test
     void testRuleProperties() {
@@ -83,7 +82,7 @@ class EmptyFinallyBlockRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected EmptyFinallyBlockRule createRule() {
         new EmptyFinallyBlockRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/basic/EmptyForStatementRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/EmptyForStatementRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class EmptyForStatementRuleTest extends AbstractRuleTestCase {
+class EmptyForStatementRuleTest extends GenericAbstractRuleTestCase<EmptyForStatementRule> {
 
     @Test
     void testRuleProperties() {
@@ -83,7 +82,7 @@ class EmptyForStatementRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected EmptyForStatementRule createRule() {
         new EmptyForStatementRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/basic/EmptyIfStatementRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/EmptyIfStatementRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class EmptyIfStatementRuleTest extends AbstractRuleTestCase {
+class EmptyIfStatementRuleTest extends GenericAbstractRuleTestCase<EmptyIfStatementRule> {
 
     @Test
     void testRuleProperties() {
@@ -71,7 +70,7 @@ class EmptyIfStatementRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected EmptyIfStatementRule createRule() {
         new EmptyIfStatementRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/basic/EmptyInstanceInitializerRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/EmptyInstanceInitializerRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class EmptyInstanceInitializerRuleTest extends AbstractRuleTestCase {
+class EmptyInstanceInitializerRuleTest extends GenericAbstractRuleTestCase<EmptyInstanceInitializerRule> {
 
     @Test
     void testRuleProperties() {
@@ -53,7 +52,7 @@ class EmptyInstanceInitializerRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected EmptyInstanceInitializerRule createRule() {
         new EmptyInstanceInitializerRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/EmptyMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/EmptyMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class EmptyMethodRuleTest extends AbstractRuleTestCase {
+class EmptyMethodRuleTest extends GenericAbstractRuleTestCase<EmptyMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -72,7 +71,7 @@ class EmptyMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected EmptyMethodRule createRule() {
         new EmptyMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/EmptyStaticInitializerRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/EmptyStaticInitializerRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class EmptyStaticInitializerRuleTest extends AbstractRuleTestCase {
+class EmptyStaticInitializerRuleTest extends GenericAbstractRuleTestCase<EmptyStaticInitializerRule> {
 
     @Test
     void testRuleProperties() {
@@ -56,7 +55,7 @@ class EmptyStaticInitializerRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected EmptyStaticInitializerRule createRule() {
         new EmptyStaticInitializerRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/EmptySwitchStatementRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/EmptySwitchStatementRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class EmptySwitchStatementRuleTest extends AbstractRuleTestCase {
+class EmptySwitchStatementRuleTest extends GenericAbstractRuleTestCase<EmptySwitchStatementRule> {
 
     @Test
     void testRuleProperties() {
@@ -59,7 +58,7 @@ class EmptySwitchStatementRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected EmptySwitchStatementRule createRule() {
         new EmptySwitchStatementRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/basic/EmptySynchronizedStatementRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/EmptySynchronizedStatementRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class EmptySynchronizedStatementRuleTest extends AbstractRuleTestCase {
+class EmptySynchronizedStatementRuleTest extends GenericAbstractRuleTestCase<EmptySynchronizedStatementRule> {
 
     @Test
     void testRuleProperties() {
@@ -69,7 +68,7 @@ class EmptySynchronizedStatementRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected EmptySynchronizedStatementRule createRule() {
         new EmptySynchronizedStatementRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/basic/EmptyTryBlockRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/EmptyTryBlockRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class EmptyTryBlockRuleTest extends AbstractRuleTestCase {
+class EmptyTryBlockRuleTest extends GenericAbstractRuleTestCase<EmptyTryBlockRule> {
 
     @Test
     void testRuleProperties() {
@@ -75,7 +74,7 @@ class EmptyTryBlockRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected EmptyTryBlockRule createRule() {
         new EmptyTryBlockRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/basic/EmptyWhileStatementRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/EmptyWhileStatementRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class EmptyWhileStatementRuleTest extends AbstractRuleTestCase {
+class EmptyWhileStatementRuleTest extends GenericAbstractRuleTestCase<EmptyWhileStatementRule> {
 
     @Test
     void testRuleProperties() {
@@ -82,7 +81,7 @@ class EmptyWhileStatementRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected EmptyWhileStatementRule createRule() {
         new EmptyWhileStatementRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/basic/EqualsAndHashCodeRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/EqualsAndHashCodeRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class EqualsAndHashCodeRuleTest extends AbstractRuleTestCase {
+class EqualsAndHashCodeRuleTest extends GenericAbstractRuleTestCase<EqualsAndHashCodeRule> {
 
     @Test
     void testRuleProperties() {
@@ -102,7 +101,7 @@ class EqualsAndHashCodeRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected EqualsAndHashCodeRule createRule() {
         new EqualsAndHashCodeRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/basic/EqualsOverloadedRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/EqualsOverloadedRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -27,7 +26,7 @@ import org.junit.Test
  * @author Marcin Smialek
  *
  */
-class EqualsOverloadedRuleTest extends AbstractRuleTestCase {
+class EqualsOverloadedRuleTest extends GenericAbstractRuleTestCase<EqualsOverloadedRule> {
 
     @Test
     void testRuleProperties() {
@@ -95,7 +94,7 @@ class EqualsOverloadedRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected EqualsOverloadedRule createRule() {
         new EqualsOverloadedRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/ExplicitGarbageCollectionRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/ExplicitGarbageCollectionRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author 'Hamlet D'Arcy'
  */
-class ExplicitGarbageCollectionRuleTest extends AbstractRuleTestCase {
+class ExplicitGarbageCollectionRuleTest extends GenericAbstractRuleTestCase<ExplicitGarbageCollectionRule> {
 
     @Test
     void testRuleProperties() {
@@ -85,7 +84,7 @@ class ExplicitGarbageCollectionRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitGarbageCollectionRule createRule() {
         new ExplicitGarbageCollectionRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/ForLoopShouldBeWhileLoopRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/ForLoopShouldBeWhileLoopRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author 'Victor Savkin'
  */
-class ForLoopShouldBeWhileLoopRuleTest extends AbstractRuleTestCase {
+class ForLoopShouldBeWhileLoopRuleTest extends GenericAbstractRuleTestCase<ForLoopShouldBeWhileLoopRule> {
 
     @Test
     void testRuleProperties() {
@@ -98,7 +97,7 @@ class ForLoopShouldBeWhileLoopRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ForLoopShouldBeWhileLoopRule createRule() {
         new ForLoopShouldBeWhileLoopRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/HardCodedWindowsFileSeparatorRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/HardCodedWindowsFileSeparatorRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class HardCodedWindowsFileSeparatorRuleTest extends AbstractRuleTestCase {
+class HardCodedWindowsFileSeparatorRuleTest extends GenericAbstractRuleTestCase<HardCodedWindowsFileSeparatorRule> {
 
     @Test
     void testRuleProperties() {
@@ -92,7 +91,7 @@ class HardCodedWindowsFileSeparatorRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected HardCodedWindowsFileSeparatorRule createRule() {
         new HardCodedWindowsFileSeparatorRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/HardCodedWindowsRootDirectoryRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/HardCodedWindowsRootDirectoryRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class HardCodedWindowsRootDirectoryRuleTest extends AbstractRuleTestCase {
+class HardCodedWindowsRootDirectoryRuleTest extends GenericAbstractRuleTestCase<HardCodedWindowsRootDirectoryRule> {
 
     @Test
     void testRuleProperties() {
@@ -91,7 +90,7 @@ class HardCodedWindowsRootDirectoryRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected HardCodedWindowsRootDirectoryRule createRule() {
         new HardCodedWindowsRootDirectoryRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/IntegerGetIntegerRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/IntegerGetIntegerRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class IntegerGetIntegerRuleTest extends AbstractRuleTestCase {
+class IntegerGetIntegerRuleTest extends GenericAbstractRuleTestCase<IntegerGetIntegerRule> {
 
     @Test
     void testRuleProperties() {
@@ -53,7 +52,7 @@ class IntegerGetIntegerRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected IntegerGetIntegerRule createRule() {
         new IntegerGetIntegerRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/MultipleUnaryOperatorsRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/MultipleUnaryOperatorsRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for MultipleUnaryOperatorsRule
  *
  * @author Chris Mair
  */
-class MultipleUnaryOperatorsRuleTest extends AbstractRuleTestCase {
+class MultipleUnaryOperatorsRuleTest extends GenericAbstractRuleTestCase<MultipleUnaryOperatorsRule> {
 
     @Test
     void testRuleProperties() {
@@ -69,7 +68,7 @@ class MultipleUnaryOperatorsRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected MultipleUnaryOperatorsRule createRule() {
         new MultipleUnaryOperatorsRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/RandomDoubleCoercedToZeroRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/RandomDoubleCoercedToZeroRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class RandomDoubleCoercedToZeroRuleTest extends AbstractRuleTestCase {
+class RandomDoubleCoercedToZeroRuleTest extends GenericAbstractRuleTestCase<RandomDoubleCoercedToZeroRule> {
 
     @Test
     void testRuleProperties() {
@@ -167,7 +166,7 @@ class RandomDoubleCoercedToZeroRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected RandomDoubleCoercedToZeroRule createRule() {
         new RandomDoubleCoercedToZeroRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/basic/RemoveAllOnSelfRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/RemoveAllOnSelfRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class RemoveAllOnSelfRuleTest extends AbstractRuleTestCase {
+class RemoveAllOnSelfRuleTest extends GenericAbstractRuleTestCase<RemoveAllOnSelfRule> {
 
     @Test
     void testRuleProperties() {
@@ -67,7 +66,7 @@ class RemoveAllOnSelfRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected RemoveAllOnSelfRule createRule() {
         new RemoveAllOnSelfRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/basic/ReturnFromFinallyBlockRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/ReturnFromFinallyBlockRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class ReturnFromFinallyBlockRuleTest extends AbstractRuleTestCase {
+class ReturnFromFinallyBlockRuleTest extends GenericAbstractRuleTestCase<ReturnFromFinallyBlockRule> {
     @Test
     void testRuleProperties() {
         assert rule.priority == 2
@@ -95,7 +94,7 @@ class ReturnFromFinallyBlockRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ReturnFromFinallyBlockRule createRule() {
         new ReturnFromFinallyBlockRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/basic/ThrowExceptionFromFinallyBlockRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/ThrowExceptionFromFinallyBlockRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.basic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class ThrowExceptionFromFinallyBlockRuleTest extends AbstractRuleTestCase {
+class ThrowExceptionFromFinallyBlockRuleTest extends GenericAbstractRuleTestCase<ThrowExceptionFromFinallyBlockRule> {
     @Test
     void testRuleProperties() {
         assert rule.priority == 2
@@ -95,7 +94,7 @@ class ThrowExceptionFromFinallyBlockRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ThrowExceptionFromFinallyBlockRule createRule() {
         new ThrowExceptionFromFinallyBlockRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/braces/ElseBlockBracesRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/braces/ElseBlockBracesRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.braces
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class ElseBlockBracesRuleTest extends AbstractRuleTestCase {
+class ElseBlockBracesRuleTest extends GenericAbstractRuleTestCase<ElseBlockBracesRule> {
 
     @Test
     void testRuleProperties() {
@@ -111,7 +110,7 @@ class ElseBlockBracesRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ElseBlockBracesRule createRule() {
         new ElseBlockBracesRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/braces/ForStatementBracesRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/braces/ForStatementBracesRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.braces
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class ForStatementBracesRuleTest extends AbstractRuleTestCase {
+class ForStatementBracesRuleTest extends GenericAbstractRuleTestCase<ForStatementBracesRule> {
 
     @Test
     void testRuleProperties() {
@@ -71,7 +70,7 @@ class ForStatementBracesRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ForStatementBracesRule createRule() {
         new ForStatementBracesRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/braces/IfStatementBracesRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/braces/IfStatementBracesRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.braces
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class IfStatementBracesRuleTest extends AbstractRuleTestCase {
+class IfStatementBracesRuleTest extends GenericAbstractRuleTestCase<IfStatementBracesRule> {
 
     @Test
     void testRuleProperties() {
@@ -71,7 +70,7 @@ class IfStatementBracesRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected IfStatementBracesRule createRule() {
         new IfStatementBracesRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/braces/WhileStatementBracesRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/braces/WhileStatementBracesRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.braces
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class WhileStatementBracesRuleTest extends AbstractRuleTestCase {
+class WhileStatementBracesRuleTest extends GenericAbstractRuleTestCase<WhileStatementBracesRule> {
 
     @Test
     void testRuleProperties() {
@@ -71,7 +70,7 @@ class WhileStatementBracesRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected WhileStatementBracesRule createRule() {
         new WhileStatementBracesRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/concurrency/BusyWaitRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/BusyWaitRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author 'Hamlet D'Arcy'
  */
-class BusyWaitRuleTest extends AbstractRuleTestCase {
+class BusyWaitRuleTest extends GenericAbstractRuleTestCase<BusyWaitRule> {
 
     @Test
     void testRuleProperties() {
@@ -89,7 +88,7 @@ class BusyWaitRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected BusyWaitRule createRule() {
         new BusyWaitRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/concurrency/DoubleCheckedLockingRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/DoubleCheckedLockingRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author 'Hamlet D'Arcy'
  */
-class DoubleCheckedLockingRuleTest extends AbstractRuleTestCase {
+class DoubleCheckedLockingRuleTest extends GenericAbstractRuleTestCase<DoubleCheckedLockingRule> {
 
     @Test
     void testRuleProperties() {
@@ -159,7 +158,7 @@ class DoubleCheckedLockingRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected DoubleCheckedLockingRule createRule() {
         new DoubleCheckedLockingRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/concurrency/InconsistentPropertyLockingRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/InconsistentPropertyLockingRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class InconsistentPropertyLockingRuleTest extends AbstractRuleTestCase {
+class InconsistentPropertyLockingRuleTest extends GenericAbstractRuleTestCase<InconsistentPropertyLockingRule> {
 
     @Test
     void testRuleProperties() {
@@ -156,7 +155,7 @@ class InconsistentPropertyLockingRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected InconsistentPropertyLockingRule createRule() {
         new InconsistentPropertyLockingRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/concurrency/InconsistentPropertySynchronizationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/InconsistentPropertySynchronizationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author 'Hamlet D'Arcy'
  */
-class InconsistentPropertySynchronizationRuleTest extends AbstractRuleTestCase {
+class InconsistentPropertySynchronizationRuleTest extends GenericAbstractRuleTestCase<InconsistentPropertySynchronizationRule> {
 
     @Test
     void testRuleProperties() {
@@ -264,7 +263,7 @@ class InconsistentPropertySynchronizationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected InconsistentPropertySynchronizationRule createRule() {
         new InconsistentPropertySynchronizationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/concurrency/NestedSynchronizationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/NestedSynchronizationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class NestedSynchronizationRuleTest extends AbstractRuleTestCase {
+class NestedSynchronizationRuleTest extends GenericAbstractRuleTestCase<NestedSynchronizationRule> {
     @Test
     void testRuleProperties() {
         assert rule.priority == 2
@@ -233,7 +232,7 @@ class NestedSynchronizationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected NestedSynchronizationRule createRule() {
         new NestedSynchronizationRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/concurrency/StaticCalendarFieldRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/StaticCalendarFieldRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Hamlet D'Arcy
  * @author Chris Mair
  */
-class StaticCalendarFieldRuleTest extends AbstractRuleTestCase {
+class StaticCalendarFieldRuleTest extends GenericAbstractRuleTestCase<StaticCalendarFieldRule> {
 
     @Test
     void testRuleProperties() {
@@ -95,7 +94,7 @@ class StaticCalendarFieldRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected StaticCalendarFieldRule createRule() {
         new StaticCalendarFieldRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/concurrency/StaticConnectionRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/StaticConnectionRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author 'Hamlet D'Arcy'
  */
-class StaticConnectionRuleTest extends AbstractRuleTestCase {
+class StaticConnectionRuleTest extends GenericAbstractRuleTestCase<StaticConnectionRule> {
 
     @Test
     void testRuleProperties() {
@@ -54,7 +53,7 @@ class StaticConnectionRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected StaticConnectionRule createRule() {
         new StaticConnectionRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/concurrency/StaticDateFormatFieldRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/StaticDateFormatFieldRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Hamlet D'Arcy
  * @author Chris Mair
  */
-class StaticDateFormatFieldRuleTest extends AbstractRuleTestCase {
+class StaticDateFormatFieldRuleTest extends GenericAbstractRuleTestCase<StaticDateFormatFieldRule> {
 
     @Test
     void testRuleProperties() {
@@ -117,7 +116,7 @@ class StaticDateFormatFieldRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected StaticDateFormatFieldRule createRule() {
         new StaticDateFormatFieldRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/concurrency/StaticMatcherFieldRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/StaticMatcherFieldRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class StaticMatcherFieldRuleTest extends AbstractRuleTestCase {
+class StaticMatcherFieldRuleTest extends GenericAbstractRuleTestCase<StaticMatcherFieldRule> {
 
     @Test
     void testRuleProperties() {
@@ -65,7 +64,7 @@ class StaticMatcherFieldRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected StaticMatcherFieldRule createRule() {
         new StaticMatcherFieldRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/concurrency/StaticSimpleDateFormatFieldRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/StaticSimpleDateFormatFieldRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class StaticSimpleDateFormatFieldRuleTest extends AbstractRuleTestCase {
+class StaticSimpleDateFormatFieldRuleTest extends GenericAbstractRuleTestCase<StaticSimpleDateFormatFieldRule> {
 
     @Test
     void testRuleProperties() {
@@ -98,7 +97,7 @@ class StaticSimpleDateFormatFieldRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected StaticSimpleDateFormatFieldRule createRule() {
         new StaticSimpleDateFormatFieldRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/concurrency/SynchronizedMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/SynchronizedMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class SynchronizedMethodRuleTest extends AbstractRuleTestCase {
+class SynchronizedMethodRuleTest extends GenericAbstractRuleTestCase<SynchronizedMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -56,7 +55,7 @@ class SynchronizedMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SynchronizedMethodRule createRule() {
         new SynchronizedMethodRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/concurrency/SynchronizedOnBoxedPrimitiveRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/SynchronizedOnBoxedPrimitiveRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class SynchronizedOnBoxedPrimitiveRuleTest extends AbstractRuleTestCase {
+class SynchronizedOnBoxedPrimitiveRuleTest extends GenericAbstractRuleTestCase<SynchronizedOnBoxedPrimitiveRule> {
 
     @Test
     void testRuleProperties() {
@@ -472,7 +471,7 @@ class SynchronizedOnBoxedPrimitiveRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SynchronizedOnBoxedPrimitiveRule createRule() {
         new SynchronizedOnBoxedPrimitiveRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/concurrency/SynchronizedOnGetClassRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/SynchronizedOnGetClassRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class SynchronizedOnGetClassRuleTest extends AbstractRuleTestCase {
+class SynchronizedOnGetClassRuleTest extends GenericAbstractRuleTestCase<SynchronizedOnGetClassRule> {
 
     @Test
     void testRuleProperties() {
@@ -76,7 +75,7 @@ class SynchronizedOnGetClassRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SynchronizedOnGetClassRule createRule() {
         new SynchronizedOnGetClassRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/concurrency/SynchronizedOnReentrantLockRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/SynchronizedOnReentrantLockRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author 'Hamlet D'Arcy'
  */
-class SynchronizedOnReentrantLockRuleTest extends AbstractRuleTestCase {
+class SynchronizedOnReentrantLockRuleTest extends GenericAbstractRuleTestCase<SynchronizedOnReentrantLockRule> {
 
     @Test
     void testRuleProperties() {
@@ -188,7 +187,7 @@ class SynchronizedOnReentrantLockRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SynchronizedOnReentrantLockRule createRule() {
         new SynchronizedOnReentrantLockRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/concurrency/SynchronizedOnStringRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/SynchronizedOnStringRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class SynchronizedOnStringRuleTest extends AbstractRuleTestCase {
+class SynchronizedOnStringRuleTest extends GenericAbstractRuleTestCase<SynchronizedOnStringRule> {
 
     @Test
     void testRuleProperties() {
@@ -184,7 +183,7 @@ class SynchronizedOnStringRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SynchronizedOnStringRule createRule() {
         new SynchronizedOnStringRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/concurrency/SynchronizedOnThisRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/SynchronizedOnThisRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class SynchronizedOnThisRuleTest extends AbstractRuleTestCase {
+class SynchronizedOnThisRuleTest extends GenericAbstractRuleTestCase<SynchronizedOnThisRule> {
 
     @Test
     void testRuleProperties() {
@@ -74,7 +73,7 @@ class SynchronizedOnThisRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SynchronizedOnThisRule createRule() {
         new SynchronizedOnThisRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/concurrency/SynchronizedReadObjectMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/SynchronizedReadObjectMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class SynchronizedReadObjectMethodRuleTest extends AbstractRuleTestCase {
+class SynchronizedReadObjectMethodRuleTest extends GenericAbstractRuleTestCase<SynchronizedReadObjectMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -87,7 +86,7 @@ class SynchronizedReadObjectMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SynchronizedReadObjectMethodRule createRule() {
         new SynchronizedReadObjectMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/concurrency/SystemRunFinalizersOnExitRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/SystemRunFinalizersOnExitRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class SystemRunFinalizersOnExitRuleTest extends AbstractRuleTestCase {
+class SystemRunFinalizersOnExitRuleTest extends GenericAbstractRuleTestCase<SystemRunFinalizersOnExitRule> {
 
     @Test
     void testRuleProperties() {
@@ -91,7 +90,7 @@ class SystemRunFinalizersOnExitRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SystemRunFinalizersOnExitRule createRule() {
         new SystemRunFinalizersOnExitRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/concurrency/ThisReferenceEscapesConstructorRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/ThisReferenceEscapesConstructorRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Artur Gajowy
  */
-class ThisReferenceEscapesConstructorRuleTest extends AbstractRuleTestCase {
+class ThisReferenceEscapesConstructorRuleTest extends GenericAbstractRuleTestCase<ThisReferenceEscapesConstructorRule> {
 
     @Test
     void testRuleProperties() {
@@ -79,7 +78,7 @@ class ThisReferenceEscapesConstructorRuleTest extends AbstractRuleTestCase {
         ' This equals exposing a half-baked object and can lead to race conditions.'
 
     @Override
-    protected Rule createRule() {
+    protected ThisReferenceEscapesConstructorRule createRule() {
         new ThisReferenceEscapesConstructorRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/concurrency/ThreadGroupRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/ThreadGroupRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ThreadGroupRuleTest extends AbstractRuleTestCase {
+class ThreadGroupRuleTest extends GenericAbstractRuleTestCase<ThreadGroupRule> {
 
     @Test
     void testRuleProperties() {
@@ -81,7 +80,7 @@ class ThreadGroupRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ThreadGroupRule createRule() {
         new ThreadGroupRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/concurrency/ThreadLocalNotStaticFinalRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/ThreadLocalNotStaticFinalRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ThreadLocalNotStaticFinalRuleTest extends AbstractRuleTestCase {
+class ThreadLocalNotStaticFinalRuleTest extends GenericAbstractRuleTestCase<ThreadLocalNotStaticFinalRule> {
 
     @Test
     void testRuleProperties() {
@@ -82,7 +81,7 @@ class ThreadLocalNotStaticFinalRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ThreadLocalNotStaticFinalRule createRule() {
         new ThreadLocalNotStaticFinalRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/concurrency/ThreadYieldRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/ThreadYieldRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
   *
   * @author Hamlet D'Arcy
   */
-class ThreadYieldRuleTest extends AbstractRuleTestCase {
+class ThreadYieldRuleTest extends GenericAbstractRuleTestCase<ThreadYieldRule> {
 
     @Test
     void testRuleProperties() {
@@ -92,7 +91,7 @@ class ThreadYieldRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ThreadYieldRule createRule() {
         new ThreadYieldRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/concurrency/UseOfNotifyMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/UseOfNotifyMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class UseOfNotifyMethodRuleTest extends AbstractRuleTestCase {
+class UseOfNotifyMethodRuleTest extends GenericAbstractRuleTestCase<UseOfNotifyMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -67,7 +66,7 @@ class UseOfNotifyMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UseOfNotifyMethodRule createRule() {
         new UseOfNotifyMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/concurrency/VolatileArrayFieldRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/VolatileArrayFieldRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class VolatileArrayFieldRuleTest extends AbstractRuleTestCase {
+class VolatileArrayFieldRuleTest extends GenericAbstractRuleTestCase<VolatileArrayFieldRule> {
 
     @Test
     void testRuleProperties() {
@@ -117,7 +116,7 @@ class VolatileArrayFieldRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected VolatileArrayFieldRule createRule() {
         new VolatileArrayFieldRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/concurrency/VolatileLongOrDoubleFieldRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/VolatileLongOrDoubleFieldRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class VolatileLongOrDoubleFieldRuleTest extends AbstractRuleTestCase {
+class VolatileLongOrDoubleFieldRuleTest extends GenericAbstractRuleTestCase<VolatileLongOrDoubleFieldRule> {
     @Test
     void testRuleProperties() {
         assert rule.priority == 2
@@ -80,7 +79,7 @@ class VolatileLongOrDoubleFieldRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected VolatileLongOrDoubleFieldRule createRule() {
         new VolatileLongOrDoubleFieldRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/concurrency/WaitOutsideOfWhileLoopRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/concurrency/WaitOutsideOfWhileLoopRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.concurrency
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class WaitOutsideOfWhileLoopRuleTest extends AbstractRuleTestCase {
+class WaitOutsideOfWhileLoopRuleTest extends GenericAbstractRuleTestCase<WaitOutsideOfWhileLoopRule> {
 
     @Test
     void testRuleProperties() {
@@ -86,7 +85,7 @@ class WaitOutsideOfWhileLoopRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected WaitOutsideOfWhileLoopRule createRule() {
         new WaitOutsideOfWhileLoopRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/convention/ConfusingTernaryRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/ConfusingTernaryRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.convention
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ConfusingTernaryRuleTest extends AbstractRuleTestCase {
+class ConfusingTernaryRuleTest extends GenericAbstractRuleTestCase<ConfusingTernaryRule> {
 
     @Test
     void testRuleProperties() {
@@ -74,7 +73,7 @@ class ConfusingTernaryRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ConfusingTernaryRule createRule() {
         new ConfusingTernaryRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/convention/CouldBeElvisRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/CouldBeElvisRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.convention
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author GUM
  */
-class CouldBeElvisRuleTest extends AbstractRuleTestCase {
+class CouldBeElvisRuleTest extends GenericAbstractRuleTestCase<CouldBeElvisRule> {
 
     @Test
     void testRuleProperties() {
@@ -145,7 +144,7 @@ class CouldBeElvisRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected CouldBeElvisRule createRule() {
         new CouldBeElvisRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/convention/CouldBeSwitchStatementRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/CouldBeSwitchStatementRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.convention
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for CouldBeSwitchStatementRule
  *
  * @author Jenn Strater
  */
-class CouldBeSwitchStatementRuleTest extends AbstractRuleTestCase {
+class CouldBeSwitchStatementRuleTest extends GenericAbstractRuleTestCase<CouldBeSwitchStatementRule> {
 
     @Test
     void testRuleProperties() {
@@ -233,7 +232,7 @@ class CouldBeSwitchStatementRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected CouldBeSwitchStatementRule createRule() {
         new CouldBeSwitchStatementRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/convention/HashtableIsObsoleteRule_HashtableTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/HashtableIsObsoleteRule_HashtableTest.groovy
@@ -16,7 +16,6 @@
 package org.codenarc.rule.convention
 
 import org.codenarc.rule.AbstractClassReferenceRuleTestCase
-import org.codenarc.rule.Rule
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class HashtableIsObsoleteRule_HashtableTest extends AbstractClassReferenceRuleTestCase {
+class HashtableIsObsoleteRule_HashtableTest extends AbstractClassReferenceRuleTestCase<HashtableIsObsoleteRule> {
 
     final String className = 'Hashtable'
     final String violationMessage = "The $className class is obsolete"
@@ -36,7 +35,7 @@ class HashtableIsObsoleteRule_HashtableTest extends AbstractClassReferenceRuleTe
     }
 
     @Override
-    protected Rule createRule() {
+    protected HashtableIsObsoleteRule createRule() {
         new HashtableIsObsoleteRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/convention/HashtableIsObsoleteRule_JavaUtilHashtableTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/HashtableIsObsoleteRule_JavaUtilHashtableTest.groovy
@@ -16,7 +16,6 @@
 package org.codenarc.rule.convention
 
 import org.codenarc.rule.AbstractClassReferenceRuleTestCase
-import org.codenarc.rule.Rule
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class HashtableIsObsoleteRule_JavaUtilHashtableTest extends AbstractClassReferenceRuleTestCase {
+class HashtableIsObsoleteRule_JavaUtilHashtableTest extends AbstractClassReferenceRuleTestCase<HashtableIsObsoleteRule> {
 
     final String className = 'java.util.Hashtable'
     final String violationMessage = "The $className class is obsolete"
@@ -36,7 +35,7 @@ class HashtableIsObsoleteRule_JavaUtilHashtableTest extends AbstractClassReferen
     }
 
     @Override
-    protected Rule createRule() {
+    protected HashtableIsObsoleteRule createRule() {
         new HashtableIsObsoleteRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/convention/IfStatementCouldBeTernaryRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/IfStatementCouldBeTernaryRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.convention
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for IfStatementCouldBeTernaryRule
  *
  * @author Chris Mair
  */
-class IfStatementCouldBeTernaryRuleTest extends AbstractRuleTestCase {
+class IfStatementCouldBeTernaryRuleTest extends GenericAbstractRuleTestCase<IfStatementCouldBeTernaryRule> {
 
     @Test
     void testRuleProperties() {
@@ -191,7 +190,7 @@ class IfStatementCouldBeTernaryRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected IfStatementCouldBeTernaryRule createRule() {
         new IfStatementCouldBeTernaryRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/convention/InvertedIfElseRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/InvertedIfElseRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.convention
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class InvertedIfElseRuleTest extends AbstractRuleTestCase {
+class InvertedIfElseRuleTest extends GenericAbstractRuleTestCase<InvertedIfElseRule> {
 
     @Test
     void testRuleProperties() {
@@ -103,7 +102,7 @@ class InvertedIfElseRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected InvertedIfElseRule createRule() {
         new InvertedIfElseRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/convention/LongLiteralWithLowerCaseLRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/LongLiteralWithLowerCaseLRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.convention
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class LongLiteralWithLowerCaseLRuleTest extends AbstractRuleTestCase {
+class LongLiteralWithLowerCaseLRuleTest extends GenericAbstractRuleTestCase<LongLiteralWithLowerCaseLRule> {
 
     @Test
     void testRuleProperties() {
@@ -61,7 +60,7 @@ class LongLiteralWithLowerCaseLRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected LongLiteralWithLowerCaseLRule createRule() {
         new LongLiteralWithLowerCaseLRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/convention/NoDefRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/NoDefRuleTest.groovy
@@ -15,15 +15,14 @@
  */
 package org.codenarc.rule.convention
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
  * @author Dominik Przybysz
  * @author Chris Mair
  */
-class NoDefRuleTest extends AbstractRuleTestCase {
+class NoDefRuleTest extends GenericAbstractRuleTestCase<NoDefRule> {
 
     @Test
     void testNoViolations() {
@@ -152,7 +151,7 @@ class NoDefRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected NoDefRule createRule() {
         new NoDefRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/convention/NoTabCharacterRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/NoTabCharacterRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.convention
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Yuriy Chulovskyy
  */
-class NoTabCharacterRuleTest extends AbstractRuleTestCase {
+class NoTabCharacterRuleTest extends GenericAbstractRuleTestCase<NoTabCharacterRule> {
 
     @Test
     void testRuleProperties() {
@@ -51,7 +50,7 @@ class NoTabCharacterRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected NoTabCharacterRule createRule() {
         new NoTabCharacterRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/convention/ParameterReassignmentRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/ParameterReassignmentRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.convention
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class ParameterReassignmentRuleTest extends AbstractRuleTestCase {
+class ParameterReassignmentRuleTest extends GenericAbstractRuleTestCase<ParameterReassignmentRule> {
 
     @Test
     void testRuleProperties() {
@@ -164,7 +163,7 @@ class ParameterReassignmentRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ParameterReassignmentRule createRule() {
         new ParameterReassignmentRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/convention/TernaryCouldBeElvisRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/TernaryCouldBeElvisRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.convention
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class TernaryCouldBeElvisRuleTest extends AbstractRuleTestCase {
+class TernaryCouldBeElvisRuleTest extends GenericAbstractRuleTestCase<TernaryCouldBeElvisRule> {
 
     @Test
     void testRuleProperties() {
@@ -90,7 +89,7 @@ class TernaryCouldBeElvisRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected TernaryCouldBeElvisRule createRule() {
         new TernaryCouldBeElvisRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/convention/TrailingCommaRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/TrailingCommaRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.convention
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for TrailingCommaRule
  *
  * @author Yuriy Chulovskyy
  */
-class TrailingCommaRuleTest extends AbstractRuleTestCase {
+class TrailingCommaRuleTest extends GenericAbstractRuleTestCase<TrailingCommaRule> {
 
     @Test
     void testRuleProperties() {
@@ -189,7 +188,7 @@ class TrailingCommaRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected TrailingCommaRule createRule() {
         new TrailingCommaRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/convention/VectorIsObsoleteRule_JavaUtilVectorTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/VectorIsObsoleteRule_JavaUtilVectorTest.groovy
@@ -16,7 +16,6 @@
 package org.codenarc.rule.convention
 
 import org.codenarc.rule.AbstractClassReferenceRuleTestCase
-import org.codenarc.rule.Rule
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class VectorIsObsoleteRule_JavaUtilVectorTest extends AbstractClassReferenceRuleTestCase {
+class VectorIsObsoleteRule_JavaUtilVectorTest extends AbstractClassReferenceRuleTestCase<VectorIsObsoleteRule> {
 
     final String className = 'java.util.Vector'
     final String violationMessage = "The $className class is obsolete"
@@ -36,7 +35,7 @@ class VectorIsObsoleteRule_JavaUtilVectorTest extends AbstractClassReferenceRule
     }
 
     @Override
-    protected Rule createRule() {
+    protected VectorIsObsoleteRule createRule() {
         new VectorIsObsoleteRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/convention/VectorIsObsoleteRule_VectorTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/VectorIsObsoleteRule_VectorTest.groovy
@@ -16,7 +16,6 @@
 package org.codenarc.rule.convention
 
 import org.codenarc.rule.AbstractClassReferenceRuleTestCase
-import org.codenarc.rule.Rule
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class VectorIsObsoleteRule_VectorTest extends AbstractClassReferenceRuleTestCase {
+class VectorIsObsoleteRule_VectorTest extends AbstractClassReferenceRuleTestCase<VectorIsObsoleteRule> {
 
     final String className = 'Vector'
     final String violationMessage = "The $className class is obsolete"
@@ -36,7 +35,7 @@ class VectorIsObsoleteRule_VectorTest extends AbstractClassReferenceRuleTestCase
     }
 
     @Override
-    protected Rule createRule() {
+    protected VectorIsObsoleteRule createRule() {
         new VectorIsObsoleteRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/design/AbstractClassWithPublicConstructorRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/AbstractClassWithPublicConstructorRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.design
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class AbstractClassWithPublicConstructorRuleTest extends AbstractRuleTestCase {
+class AbstractClassWithPublicConstructorRuleTest extends GenericAbstractRuleTestCase<AbstractClassWithPublicConstructorRule> {
 
     @Test
     void testRuleProperties() {
@@ -78,7 +77,7 @@ class AbstractClassWithPublicConstructorRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected AbstractClassWithPublicConstructorRule createRule() {
         new AbstractClassWithPublicConstructorRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/design/AbstractClassWithoutAbstractMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/AbstractClassWithoutAbstractMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.design
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author 'Hamlet D'Arcy'
  */
-class AbstractClassWithoutAbstractMethodRuleTest extends AbstractRuleTestCase {
+class AbstractClassWithoutAbstractMethodRuleTest extends GenericAbstractRuleTestCase<AbstractClassWithoutAbstractMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -71,7 +70,7 @@ class AbstractClassWithoutAbstractMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected AbstractClassWithoutAbstractMethodRule createRule() {
         new AbstractClassWithoutAbstractMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/design/AssignmentToStaticFieldFromInstanceMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/AssignmentToStaticFieldFromInstanceMethodRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.design
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for AssignmentToStaticFieldFromInstanceMethodRule
  *
  * @author Chris Mair
  */
-class AssignmentToStaticFieldFromInstanceMethodRuleTest extends AbstractRuleTestCase {
+class AssignmentToStaticFieldFromInstanceMethodRuleTest extends GenericAbstractRuleTestCase<AssignmentToStaticFieldFromInstanceMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -136,7 +135,7 @@ class AssignmentToStaticFieldFromInstanceMethodRuleTest extends AbstractRuleTest
     }
 
     @Override
-    protected Rule createRule() {
+    protected AssignmentToStaticFieldFromInstanceMethodRule createRule() {
         new AssignmentToStaticFieldFromInstanceMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/design/BooleanMethodReturnsNullRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/BooleanMethodReturnsNullRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.design
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class BooleanMethodReturnsNullRuleTest extends AbstractRuleTestCase {
+class BooleanMethodReturnsNullRuleTest extends GenericAbstractRuleTestCase<BooleanMethodReturnsNullRule> {
 
     @Test
     void testRuleProperties() {
@@ -246,7 +245,7 @@ class BooleanMethodReturnsNullRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected BooleanMethodReturnsNullRule createRule() {
         new BooleanMethodReturnsNullRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/design/BuilderMethodWithSideEffectsRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/BuilderMethodWithSideEffectsRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.design
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class BuilderMethodWithSideEffectsRuleTest extends AbstractRuleTestCase {
+class BuilderMethodWithSideEffectsRuleTest extends GenericAbstractRuleTestCase<BuilderMethodWithSideEffectsRule> {
 
     @Test
     void testRuleProperties() {
@@ -111,7 +110,7 @@ class BuilderMethodWithSideEffectsRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected BuilderMethodWithSideEffectsRule createRule() {
         new BuilderMethodWithSideEffectsRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/design/CloneWithoutCloneableRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/CloneWithoutCloneableRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.design
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for CloneWithoutCloneableRule
  *
  * @author ArturGajowy
  */
-class CloneWithoutCloneableRuleTest extends AbstractRuleTestCase {
+class CloneWithoutCloneableRuleTest extends GenericAbstractRuleTestCase<CloneWithoutCloneableRule> {
 
     @Test
     void testRuleProperties() {
@@ -107,7 +106,7 @@ class CloneWithoutCloneableRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected CloneWithoutCloneableRule createRule() {
         new CloneWithoutCloneableRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/design/CloneableWithoutCloneRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/CloneableWithoutCloneRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.design
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class CloneableWithoutCloneRuleTest extends AbstractRuleTestCase {
+class CloneableWithoutCloneRuleTest extends GenericAbstractRuleTestCase<CloneableWithoutCloneRule> {
 
     @Test
     void testRuleProperties() {
@@ -98,7 +97,7 @@ class CloneableWithoutCloneRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected CloneableWithoutCloneRule createRule() {
         new CloneableWithoutCloneRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/design/ConstantsOnlyInterfaceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/ConstantsOnlyInterfaceRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.design
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ConstantsOnlyInterfaceRuleTest extends AbstractRuleTestCase {
+class ConstantsOnlyInterfaceRuleTest extends GenericAbstractRuleTestCase<ConstantsOnlyInterfaceRule> {
 
     @Test
     void testRuleProperties() {
@@ -74,7 +73,7 @@ class ConstantsOnlyInterfaceRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ConstantsOnlyInterfaceRule createRule() {
         new ConstantsOnlyInterfaceRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/design/EmptyMethodInAbstractClassRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/EmptyMethodInAbstractClassRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.design
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class EmptyMethodInAbstractClassRuleTest extends AbstractRuleTestCase {
+class EmptyMethodInAbstractClassRuleTest extends GenericAbstractRuleTestCase<EmptyMethodInAbstractClassRule> {
 
     @Test
     void testRuleProperties() {
@@ -106,7 +105,7 @@ class EmptyMethodInAbstractClassRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected EmptyMethodInAbstractClassRule createRule() {
         new EmptyMethodInAbstractClassRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/design/FinalClassWithProtectedMemberRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/FinalClassWithProtectedMemberRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.design
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class FinalClassWithProtectedMemberRuleTest extends AbstractRuleTestCase {
+class FinalClassWithProtectedMemberRuleTest extends GenericAbstractRuleTestCase<FinalClassWithProtectedMemberRule> {
 
     @Test
     void testRuleProperties() {
@@ -95,7 +94,7 @@ class FinalClassWithProtectedMemberRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected FinalClassWithProtectedMemberRule createRule() {
         new FinalClassWithProtectedMemberRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/design/ImplementationAsTypeRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/ImplementationAsTypeRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.design
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Before
 import org.junit.Test
 
@@ -25,7 +24,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class ImplementationAsTypeRuleTest extends AbstractRuleTestCase {
+class ImplementationAsTypeRuleTest extends GenericAbstractRuleTestCase<ImplementationAsTypeRule> {
     private static final BAD_TYPES = [
         'java.util.ArrayList',
         'java.util.ArrayList<String>',
@@ -177,7 +176,7 @@ class ImplementationAsTypeRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ImplementationAsTypeRule createRule() {
         new ImplementationAsTypeRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/design/InstanceofRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/InstanceofRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.design
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for InstanceofRule
  *
  * @author Chris Mair
  */
-class InstanceofRuleTest extends AbstractRuleTestCase {
+class InstanceofRuleTest extends GenericAbstractRuleTestCase<InstanceofRule> {
 
     @Test
     void testRuleProperties() {
@@ -94,7 +93,7 @@ class InstanceofRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected InstanceofRule createRule() {
         new InstanceofRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/design/LocaleSetDefaultRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/LocaleSetDefaultRuleTest.groovy
@@ -15,9 +15,8 @@
  */
 package org.codenarc.rule.design
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for LocaleSetDefaultRule
@@ -25,7 +24,7 @@ import org.codenarc.rule.AbstractRuleTestCase
  * @author mingzhi.huang, rob.patrick
  * @author Chris Mair
  */
-class LocaleSetDefaultRuleTest extends AbstractRuleTestCase {
+class LocaleSetDefaultRuleTest extends GenericAbstractRuleTestCase<LocaleSetDefaultRule> {
 
     @Test
     void testRuleProperties() {
@@ -72,7 +71,7 @@ class LocaleSetDefaultRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected LocaleSetDefaultRule createRule() {
         new LocaleSetDefaultRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/design/NestedForLoopRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/NestedForLoopRuleTest.groovy
@@ -15,15 +15,15 @@
  */
 package org.codenarc.rule.design
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
+
 /**
  * Tests for NestedForLoopRule
  *
  * @author Maciej Ziarko
  */
-class NestedForLoopRuleTest extends AbstractRuleTestCase {
+class NestedForLoopRuleTest extends GenericAbstractRuleTestCase<NestedForLoopRule> {
 
     @Test
     void testRuleProperties() {
@@ -98,7 +98,7 @@ class NestedForLoopRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected NestedForLoopRule createRule() {
         new NestedForLoopRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/design/PrivateFieldCouldBeFinalRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/PrivateFieldCouldBeFinalRuleTest.groovy
@@ -15,8 +15,7 @@
  */
  package org.codenarc.rule.design
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class PrivateFieldCouldBeFinalRuleTest extends AbstractRuleTestCase {
+class PrivateFieldCouldBeFinalRuleTest extends GenericAbstractRuleTestCase<PrivateFieldCouldBeFinalRule> {
 
     private static final VIOLATION_MESSAGE = 'Private field [count] in class MyClass is only'
 
@@ -463,7 +462,7 @@ class PrivateFieldCouldBeFinalRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected PrivateFieldCouldBeFinalRule createRule() {
         new PrivateFieldCouldBeFinalRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/design/PublicInstanceFieldRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/PublicInstanceFieldRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.design
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Victor Savkin
   */
-class PublicInstanceFieldRuleTest extends AbstractRuleTestCase {
+class PublicInstanceFieldRuleTest extends GenericAbstractRuleTestCase<PublicInstanceFieldRule> {
 
     @Test
     void testRuleProperties() {
@@ -73,7 +72,7 @@ class PublicInstanceFieldRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected PublicInstanceFieldRule createRule() {
         new PublicInstanceFieldRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/design/ReturnsNullInsteadOfEmptyArrayRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/ReturnsNullInsteadOfEmptyArrayRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.design
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ReturnsNullInsteadOfEmptyArrayRuleTest extends AbstractRuleTestCase {
+class ReturnsNullInsteadOfEmptyArrayRuleTest extends GenericAbstractRuleTestCase<ReturnsNullInsteadOfEmptyArrayRule> {
 
     @Test
     void testRuleProperties() {
@@ -204,7 +203,7 @@ class ReturnsNullInsteadOfEmptyArrayRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ReturnsNullInsteadOfEmptyArrayRule createRule() {
         new ReturnsNullInsteadOfEmptyArrayRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/design/ReturnsNullInsteadOfEmptyCollectionRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/ReturnsNullInsteadOfEmptyCollectionRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.design
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ReturnsNullInsteadOfEmptyCollectionRuleTest extends AbstractRuleTestCase {
+class ReturnsNullInsteadOfEmptyCollectionRuleTest extends GenericAbstractRuleTestCase<ReturnsNullInsteadOfEmptyCollectionRule> {
 
     @Test
     void testRuleProperties() {
@@ -298,7 +297,7 @@ class ReturnsNullInsteadOfEmptyCollectionRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ReturnsNullInsteadOfEmptyCollectionRule createRule() {
         new ReturnsNullInsteadOfEmptyCollectionRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/design/SimpleDateFormatMissingLocaleRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/SimpleDateFormatMissingLocaleRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.design
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class SimpleDateFormatMissingLocaleRuleTest extends AbstractRuleTestCase {
+class SimpleDateFormatMissingLocaleRuleTest extends GenericAbstractRuleTestCase<SimpleDateFormatMissingLocaleRule> {
 
     private static final VIOLATION_MESSAGE = 'Created an instance of SimpleDateFormat without specifying a Locale'
 
@@ -73,7 +72,7 @@ class SimpleDateFormatMissingLocaleRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SimpleDateFormatMissingLocaleRule createRule() {
         new SimpleDateFormatMissingLocaleRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/design/StatelessSingletonRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/StatelessSingletonRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.design
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Victor Savkin
   */
-class StatelessSingletonRuleTest extends AbstractRuleTestCase {
+class StatelessSingletonRuleTest extends GenericAbstractRuleTestCase<StatelessSingletonRule> {
 
     @Test
     void testRuleProperties() {
@@ -179,7 +178,7 @@ class StatelessSingletonRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected StatelessSingletonRule createRule() {
         new StatelessSingletonRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/design/ToStringReturnsNullRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/design/ToStringReturnsNullRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.design
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class ToStringReturnsNullRuleTest extends AbstractRuleTestCase {
+class ToStringReturnsNullRuleTest extends GenericAbstractRuleTestCase<ToStringReturnsNullRule> {
 
     private static final String ERROR_MESSAGE = 'The toString() method within class MyClass returns null'
 
@@ -132,7 +131,7 @@ class ToStringReturnsNullRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ToStringReturnsNullRule createRule() {
         new ToStringReturnsNullRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/dry/DuplicateListLiteralRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/dry/DuplicateListLiteralRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.dry
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class DuplicateListLiteralRuleTest extends AbstractRuleTestCase {
+class DuplicateListLiteralRuleTest extends GenericAbstractRuleTestCase<DuplicateListLiteralRule> {
 
     @Test
     void testRuleProperties() {
@@ -168,7 +167,7 @@ class DuplicateListLiteralRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected DuplicateListLiteralRule createRule() {
         new DuplicateListLiteralRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/dry/DuplicateMapLiteralRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/dry/DuplicateMapLiteralRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.dry
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class DuplicateMapLiteralRuleTest extends AbstractRuleTestCase {
+class DuplicateMapLiteralRuleTest extends GenericAbstractRuleTestCase<DuplicateMapLiteralRule> {
 
     @Test
     void testRuleProperties() {
@@ -225,7 +224,7 @@ class DuplicateMapLiteralRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected DuplicateMapLiteralRule createRule() {
         new DuplicateMapLiteralRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/dry/DuplicateNumberLiteralRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/dry/DuplicateNumberLiteralRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.dry
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class DuplicateNumberLiteralRuleTest extends AbstractRuleTestCase {
+class DuplicateNumberLiteralRuleTest extends GenericAbstractRuleTestCase<DuplicateNumberLiteralRule> {
 
     @Test
     void testRuleProperties() {
@@ -250,7 +249,7 @@ class DuplicateNumberLiteralRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected DuplicateNumberLiteralRule createRule() {
         new DuplicateNumberLiteralRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/dry/DuplicateStringLiteralRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/dry/DuplicateStringLiteralRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.dry
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class DuplicateStringLiteralRuleTest extends AbstractRuleTestCase {
+class DuplicateStringLiteralRuleTest extends GenericAbstractRuleTestCase<DuplicateStringLiteralRule> {
 
     @Test
     void testRuleProperties() {
@@ -240,7 +239,7 @@ class DuplicateStringLiteralRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected DuplicateStringLiteralRule createRule() {
         new DuplicateStringLiteralRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/enhanced/MissingOverrideAnnotationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/enhanced/MissingOverrideAnnotationRuleTest.groovy
@@ -16,8 +16,7 @@
 package org.codenarc.rule.enhanced
 
 import org.codehaus.groovy.control.Phases
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  *
  * @author Marcin Erdmann
  */
-class MissingOverrideAnnotationRuleTest extends AbstractRuleTestCase {
+class MissingOverrideAnnotationRuleTest extends GenericAbstractRuleTestCase<MissingOverrideAnnotationRule> {
 
     @Test
     void testRuleProperties() {
@@ -267,7 +266,7 @@ class MissingOverrideAnnotationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected MissingOverrideAnnotationRule createRule() {
         new MissingOverrideAnnotationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/exceptions/CatchArrayIndexOutOfBoundsExceptionRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/exceptions/CatchArrayIndexOutOfBoundsExceptionRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.exceptions
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class CatchArrayIndexOutOfBoundsExceptionRuleTest extends AbstractRuleTestCase {
+class CatchArrayIndexOutOfBoundsExceptionRuleTest extends GenericAbstractRuleTestCase<CatchArrayIndexOutOfBoundsExceptionRule> {
 
     @Test
     void testRuleProperties() {
@@ -62,7 +61,7 @@ class CatchArrayIndexOutOfBoundsExceptionRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected CatchArrayIndexOutOfBoundsExceptionRule createRule() {
         new CatchArrayIndexOutOfBoundsExceptionRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/exceptions/CatchErrorRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/exceptions/CatchErrorRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.exceptions
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class CatchErrorRuleTest extends AbstractRuleTestCase {
+class CatchErrorRuleTest extends GenericAbstractRuleTestCase<CatchErrorRule> {
 
     @Test
     void testRuleProperties() {
@@ -66,7 +65,7 @@ class CatchErrorRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected CatchErrorRule createRule() {
         new CatchErrorRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/exceptions/CatchExceptionRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/exceptions/CatchExceptionRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.exceptions
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class CatchExceptionRuleTest extends AbstractRuleTestCase {
+class CatchExceptionRuleTest extends GenericAbstractRuleTestCase<CatchExceptionRule> {
 
     @Test
     void testRuleProperties() {
@@ -62,7 +61,7 @@ class CatchExceptionRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected CatchExceptionRule createRule() {
         new CatchExceptionRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/exceptions/CatchIllegalMonitorStateExceptionRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/exceptions/CatchIllegalMonitorStateExceptionRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.exceptions
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class CatchIllegalMonitorStateExceptionRuleTest extends AbstractRuleTestCase {
+class CatchIllegalMonitorStateExceptionRuleTest extends GenericAbstractRuleTestCase<CatchIllegalMonitorStateExceptionRule> {
 
     @Test
     void testRuleProperties() {
@@ -62,7 +61,7 @@ class CatchIllegalMonitorStateExceptionRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected CatchIllegalMonitorStateExceptionRule createRule() {
         new CatchIllegalMonitorStateExceptionRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/exceptions/CatchIndexOutOfBoundsExceptionRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/exceptions/CatchIndexOutOfBoundsExceptionRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.exceptions
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class CatchIndexOutOfBoundsExceptionRuleTest extends AbstractRuleTestCase {
+class CatchIndexOutOfBoundsExceptionRuleTest extends GenericAbstractRuleTestCase<CatchIndexOutOfBoundsExceptionRule> {
 
     @Test
     void testRuleProperties() {
@@ -62,7 +61,7 @@ class CatchIndexOutOfBoundsExceptionRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected CatchIndexOutOfBoundsExceptionRule createRule() {
         new CatchIndexOutOfBoundsExceptionRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/exceptions/CatchNullPointerExceptionRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/exceptions/CatchNullPointerExceptionRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.exceptions
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class CatchNullPointerExceptionRuleTest extends AbstractRuleTestCase {
+class CatchNullPointerExceptionRuleTest extends GenericAbstractRuleTestCase<CatchNullPointerExceptionRule> {
 
     @Test
     void testRuleProperties() {
@@ -62,7 +61,7 @@ class CatchNullPointerExceptionRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected CatchNullPointerExceptionRule createRule() {
         new CatchNullPointerExceptionRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/exceptions/CatchRuntimeExceptionRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/exceptions/CatchRuntimeExceptionRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.exceptions
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class CatchRuntimeExceptionRuleTest extends AbstractRuleTestCase {
+class CatchRuntimeExceptionRuleTest extends GenericAbstractRuleTestCase<CatchRuntimeExceptionRule> {
 
     @Test
     void testRuleProperties() {
@@ -62,7 +61,7 @@ class CatchRuntimeExceptionRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected CatchRuntimeExceptionRule createRule() {
         new CatchRuntimeExceptionRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/exceptions/CatchThrowableRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/exceptions/CatchThrowableRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.exceptions
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class CatchThrowableRuleTest extends AbstractRuleTestCase {
+class CatchThrowableRuleTest extends GenericAbstractRuleTestCase<CatchThrowableRule> {
 
     @Test
     void testRuleProperties() {
@@ -62,7 +61,7 @@ class CatchThrowableRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected CatchThrowableRule createRule() {
         new CatchThrowableRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/exceptions/ConfusingClassNamedExceptionRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/exceptions/ConfusingClassNamedExceptionRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.exceptions
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Your Name Here
   */
-class ConfusingClassNamedExceptionRuleTest extends AbstractRuleTestCase {
+class ConfusingClassNamedExceptionRuleTest extends GenericAbstractRuleTestCase<ConfusingClassNamedExceptionRule> {
 
     @Test
     void testRuleProperties() {
@@ -82,7 +81,7 @@ class ConfusingClassNamedExceptionRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ConfusingClassNamedExceptionRule createRule() {
         new ConfusingClassNamedExceptionRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/exceptions/ExceptionExtendsErrorRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/exceptions/ExceptionExtendsErrorRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.exceptions
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class ExceptionExtendsErrorRuleTest extends AbstractRuleTestCase {
+class ExceptionExtendsErrorRuleTest extends GenericAbstractRuleTestCase<ExceptionExtendsErrorRule> {
 
     @Test
     void testRuleProperties() {
@@ -53,7 +52,7 @@ class ExceptionExtendsErrorRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExceptionExtendsErrorRule createRule() {
         new ExceptionExtendsErrorRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/exceptions/ExceptionExtendsThrowableRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/exceptions/ExceptionExtendsThrowableRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.exceptions
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for ExceptionExtendsThrowableRule
  *
  * @author Chris Mair
  */
-class ExceptionExtendsThrowableRuleTest extends AbstractRuleTestCase {
+class ExceptionExtendsThrowableRuleTest extends GenericAbstractRuleTestCase<ExceptionExtendsThrowableRule> {
 
     @Test
     void testRuleProperties() {
@@ -50,7 +49,7 @@ class ExceptionExtendsThrowableRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExceptionExtendsThrowableRule createRule() {
         new ExceptionExtendsThrowableRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/exceptions/ExceptionNotThrownRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/exceptions/ExceptionNotThrownRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.exceptions
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for ExceptionNotThrownRule
  *
  * @author Chris Mair
  */
-class ExceptionNotThrownRuleTest extends AbstractRuleTestCase {
+class ExceptionNotThrownRuleTest extends GenericAbstractRuleTestCase<ExceptionNotThrownRule> {
 
     @Test
     void testRuleProperties() {
@@ -100,7 +99,7 @@ class ExceptionNotThrownRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExceptionNotThrownRule createRule() {
         new ExceptionNotThrownRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/exceptions/MissingNewInThrowStatementRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/exceptions/MissingNewInThrowStatementRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.exceptions
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class MissingNewInThrowStatementRuleTest extends AbstractRuleTestCase {
+class MissingNewInThrowStatementRuleTest extends GenericAbstractRuleTestCase<MissingNewInThrowStatementRule> {
 
     @Test
     void testRuleProperties() {
@@ -75,7 +74,7 @@ class MissingNewInThrowStatementRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected MissingNewInThrowStatementRule createRule() {
         new MissingNewInThrowStatementRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/exceptions/ReturnNullFromCatchBlockRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/exceptions/ReturnNullFromCatchBlockRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.exceptions
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class ReturnNullFromCatchBlockRuleTest extends AbstractRuleTestCase {
+class ReturnNullFromCatchBlockRuleTest extends GenericAbstractRuleTestCase<ReturnNullFromCatchBlockRule> {
 
     @Test
     void testRuleProperties() {
@@ -106,7 +105,7 @@ class ReturnNullFromCatchBlockRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ReturnNullFromCatchBlockRule createRule() {
         new ReturnNullFromCatchBlockRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/exceptions/SwallowThreadDeathRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/exceptions/SwallowThreadDeathRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.exceptions
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Rob Fletcher
  * @author Klaus Baumecker
   */
-class SwallowThreadDeathRuleTest extends AbstractRuleTestCase {
+class SwallowThreadDeathRuleTest extends GenericAbstractRuleTestCase<SwallowThreadDeathRule> {
 
     @Test
     void testRuleProperties() {
@@ -108,7 +107,7 @@ class SwallowThreadDeathRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SwallowThreadDeathRule createRule() {
         new SwallowThreadDeathRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/exceptions/ThrowErrorRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/exceptions/ThrowErrorRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.exceptions
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class ThrowErrorRuleTest extends AbstractRuleTestCase {
+class ThrowErrorRuleTest extends GenericAbstractRuleTestCase<ThrowErrorRule> {
     @Test
     void testRuleProperties() {
         assert rule.priority == 2
@@ -73,7 +72,7 @@ class ThrowErrorRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ThrowErrorRule createRule() {
         new ThrowErrorRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/exceptions/ThrowExceptionRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/exceptions/ThrowExceptionRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.exceptions
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class ThrowExceptionRuleTest extends AbstractRuleTestCase {
+class ThrowExceptionRuleTest extends GenericAbstractRuleTestCase<ThrowExceptionRule> {
     @Test
     void testRuleProperties() {
         assert rule.priority == 2
@@ -73,7 +72,7 @@ class ThrowExceptionRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ThrowExceptionRule createRule() {
         new ThrowExceptionRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/exceptions/ThrowNullPointerExceptionRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/exceptions/ThrowNullPointerExceptionRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.exceptions
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class ThrowNullPointerExceptionRuleTest extends AbstractRuleTestCase {
+class ThrowNullPointerExceptionRuleTest extends GenericAbstractRuleTestCase<ThrowNullPointerExceptionRule> {
     @Test
     void testRuleProperties() {
         assert rule.priority == 2
@@ -73,7 +72,7 @@ class ThrowNullPointerExceptionRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ThrowNullPointerExceptionRule createRule() {
         new ThrowNullPointerExceptionRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/exceptions/ThrowRuntimeExceptionRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/exceptions/ThrowRuntimeExceptionRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.exceptions
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class ThrowRuntimeExceptionRuleTest extends AbstractRuleTestCase {
+class ThrowRuntimeExceptionRuleTest extends GenericAbstractRuleTestCase<ThrowRuntimeExceptionRule> {
     @Test
     void testRuleProperties() {
         assert rule.priority == 2
@@ -73,7 +72,7 @@ class ThrowRuntimeExceptionRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ThrowRuntimeExceptionRule createRule() {
         new ThrowRuntimeExceptionRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/exceptions/ThrowThrowableRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/exceptions/ThrowThrowableRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.exceptions
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class ThrowThrowableRuleTest extends AbstractRuleTestCase {
+class ThrowThrowableRuleTest extends GenericAbstractRuleTestCase<ThrowThrowableRule> {
     @Test
     void testRuleProperties() {
         assert rule.priority == 2
@@ -73,7 +72,7 @@ class ThrowThrowableRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ThrowThrowableRule createRule() {
         new ThrowThrowableRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/formatting/BlankLineBeforePackageRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/BlankLineBeforePackageRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Joe Sondow
  */
 @SuppressWarnings('ConsecutiveBlankLines')
-class BlankLineBeforePackageRuleTest extends AbstractRuleTestCase {
+class BlankLineBeforePackageRuleTest extends GenericAbstractRuleTestCase<BlankLineBeforePackageRule> {
 
     @Test
     void testRuleProperties() {
@@ -128,7 +127,7 @@ class BlankLineBeforePackageRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected BlankLineBeforePackageRule createRule() {
         new BlankLineBeforePackageRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/BracesForClassRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/BracesForClassRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Hamlet D'Arcy
  * @author Chris Mair
   */
-class BracesForClassRuleTest extends AbstractRuleTestCase {
+class BracesForClassRuleTest extends GenericAbstractRuleTestCase<BracesForClassRule> {
 
     @Test
     void testRuleProperties() {
@@ -222,7 +221,7 @@ class BracesForClassRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected BracesForClassRule createRule() {
         new BracesForClassRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/BracesForForLoopRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/BracesForForLoopRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Hamlet D'Arcy
  * @author Chris Mair
  */
-class BracesForForLoopRuleTest extends AbstractRuleTestCase {
+class BracesForForLoopRuleTest extends GenericAbstractRuleTestCase<BracesForForLoopRule> {
 
     @Test
     void testRuleProperties() {
@@ -110,7 +109,7 @@ class BracesForForLoopRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected BracesForForLoopRule createRule() {
         new BracesForForLoopRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/BracesForIfElseRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/BracesForIfElseRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -26,7 +25,7 @@ import org.junit.Test
  * @author <a href="mailto:geli.crick@osoco.es">Geli Crick</a>
  * @author Chris Mair
   */
-class BracesForIfElseRuleTest extends AbstractRuleTestCase {
+class BracesForIfElseRuleTest extends GenericAbstractRuleTestCase<BracesForIfElseRule> {
 
     @Test
     void testRuleProperties() {
@@ -141,7 +140,7 @@ class BracesForIfElseRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected BracesForIfElseRule createRule() {
         BracesForIfElseRule rule = new BracesForIfElseRule()
         rule.validateElse = true
 

--- a/src/test/groovy/org/codenarc/rule/formatting/BracesForMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/BracesForMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -26,7 +25,7 @@ import org.junit.Test
  * @author Hamlet D'Arcy
  * @author Chris Mair
  */
-class BracesForMethodRuleTest extends AbstractRuleTestCase {
+class BracesForMethodRuleTest extends GenericAbstractRuleTestCase<BracesForMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -309,7 +308,7 @@ class BracesForMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected BracesForMethodRule createRule() {
         new BracesForMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/BracesForTryCatchFinallyRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/BracesForTryCatchFinallyRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Hamlet D'Arcy
  * @author <a href="mailto:geli.crick@osoco.es">Geli Crick</a>
   */
-class BracesForTryCatchFinallyRuleTest extends AbstractRuleTestCase {
+class BracesForTryCatchFinallyRuleTest extends GenericAbstractRuleTestCase<BracesForTryCatchFinallyRule> {
 
     @Test
     void testRuleProperties() {
@@ -111,7 +110,7 @@ class BracesForTryCatchFinallyRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected BracesForTryCatchFinallyRule createRule() {
         BracesForTryCatchFinallyRule rule = new BracesForTryCatchFinallyRule()
         rule.validateCatch = true
         rule.validateFinally = true

--- a/src/test/groovy/org/codenarc/rule/formatting/ClassJavadocRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/ClassJavadocRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.codenarc.source.SourceString
 import org.junit.Test
 
@@ -26,7 +25,7 @@ import org.junit.Test
  * @author Hamlet D'Arcy
  * @author Chris Mair
   */
-class ClassJavadocRuleTest extends AbstractRuleTestCase {
+class ClassJavadocRuleTest extends GenericAbstractRuleTestCase<ClassJavadocRule> {
 
     static skipTestThatUnrelatedCodeHasNoViolations
 
@@ -198,7 +197,7 @@ class ClassJavadocRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ClassJavadocRule createRule() {
         new ClassJavadocRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/ClosureStatementOnOpeningLineOfMultipleLineClosureRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/ClosureStatementOnOpeningLineOfMultipleLineClosureRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for ClosureStatementOnOpeningLineOfMultipleLineClosureRule
  *
  * @author Chris Mair
  */
-class ClosureStatementOnOpeningLineOfMultipleLineClosureRuleTest extends AbstractRuleTestCase {
+class ClosureStatementOnOpeningLineOfMultipleLineClosureRuleTest extends GenericAbstractRuleTestCase<ClosureStatementOnOpeningLineOfMultipleLineClosureRule> {
 
     @Test
     void testRuleProperties() {
@@ -117,7 +116,7 @@ class ClosureStatementOnOpeningLineOfMultipleLineClosureRuleTest extends Abstrac
     }
 
     @Override
-    protected Rule createRule() {
+    protected ClosureStatementOnOpeningLineOfMultipleLineClosureRule createRule() {
         new ClosureStatementOnOpeningLineOfMultipleLineClosureRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/ConsecutiveBlankLinesRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/ConsecutiveBlankLinesRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Joe Sondow
  */
 @SuppressWarnings('ConsecutiveBlankLines')
-class ConsecutiveBlankLinesRuleTest extends AbstractRuleTestCase {
+class ConsecutiveBlankLinesRuleTest extends GenericAbstractRuleTestCase<ConsecutiveBlankLinesRule> {
 
     @Test
     void testRuleProperties() {
@@ -103,7 +102,7 @@ class ConsecutiveBlankLinesRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ConsecutiveBlankLinesRule createRule() {
         new ConsecutiveBlankLinesRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/FileEndsWithoutNewlineRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/FileEndsWithoutNewlineRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Joe Sondow
  */
-class FileEndsWithoutNewlineRuleTest extends AbstractRuleTestCase {
+class FileEndsWithoutNewlineRuleTest extends GenericAbstractRuleTestCase<FileEndsWithoutNewlineRule> {
 
     def skipTestThatUnrelatedCodeHasNoViolations
     def skipTestThatInvalidCodeHasNoViolations
@@ -61,7 +60,7 @@ class FileEndsWithoutNewlineRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected FileEndsWithoutNewlineRule createRule() {
         new FileEndsWithoutNewlineRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/IndentationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/IndentationRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for IndentationRule
  *
  * @author Chris Mair
  */
-class IndentationRuleTest extends AbstractRuleTestCase {
+class IndentationRuleTest extends GenericAbstractRuleTestCase<IndentationRule> {
 
     @Test
     void testRuleProperties() {
@@ -688,7 +687,7 @@ class IndentationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected IndentationRule createRule() {
         new IndentationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/LineLengthRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/LineLengthRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Hamlet D'Arcy
  * @author <a href="mailto:geli.crick@osoco.es">Geli Crick</a>
   */
-class LineLengthRuleTest extends AbstractRuleTestCase {
+class LineLengthRuleTest extends GenericAbstractRuleTestCase<LineLengthRule> {
 
     @Test
     void testRuleProperties() {
@@ -146,7 +145,7 @@ class LineLengthRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected LineLengthRule createRule() {
         new LineLengthRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/MissingBlankLineAfterImportsRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/MissingBlankLineAfterImportsRuleTest.groovy
@@ -15,14 +15,13 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
  * Tests for MissingBlankLineAfterImportsRule
  */
-class MissingBlankLineAfterImportsRuleTest extends AbstractRuleTestCase {
+class MissingBlankLineAfterImportsRuleTest extends GenericAbstractRuleTestCase<MissingBlankLineAfterImportsRule> {
 
     @Test
     void testRuleProperties() {
@@ -60,7 +59,7 @@ class MissingBlankLineAfterImportsRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected MissingBlankLineAfterImportsRule createRule() {
         new MissingBlankLineAfterImportsRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/MissingBlankLineAfterPackageRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/MissingBlankLineAfterPackageRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Joe Sondow
  */
 @SuppressWarnings('MissingBlankLineAfterImports')
-class MissingBlankLineAfterPackageRuleTest extends AbstractRuleTestCase {
+class MissingBlankLineAfterPackageRuleTest extends GenericAbstractRuleTestCase<MissingBlankLineAfterPackageRule> {
 
     @Test
     void testRuleProperties() {
@@ -140,7 +139,7 @@ class MissingBlankLineAfterPackageRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected MissingBlankLineAfterPackageRule createRule() {
         new MissingBlankLineAfterPackageRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterCatchRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterCatchRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class SpaceAfterCatchRuleTest extends AbstractRuleTestCase {
+class SpaceAfterCatchRuleTest extends GenericAbstractRuleTestCase<SpaceAfterCatchRule> {
 
     private static final MESSAGE = 'The catch keyword within class None is not followed by a single space'
 
@@ -57,7 +56,7 @@ class SpaceAfterCatchRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SpaceAfterCatchRule createRule() {
         new SpaceAfterCatchRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterClosingBraceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterClosingBraceRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class SpaceAfterClosingBraceRuleTest extends AbstractRuleTestCase {
+class SpaceAfterClosingBraceRuleTest extends GenericAbstractRuleTestCase<SpaceAfterClosingBraceRule> {
 
     private static final String BLOCK_VIOLATION_MESSAGE = 'The closing brace for the block in class None is not followed by a space or whitespace'
 
@@ -305,7 +304,7 @@ c        '''
     }
 
     @Override
-    protected Rule createRule() {
+    protected SpaceAfterClosingBraceRule createRule() {
         new SpaceAfterClosingBraceRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterCommaRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterCommaRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class SpaceAfterCommaRuleTest extends AbstractRuleTestCase {
+class SpaceAfterCommaRuleTest extends GenericAbstractRuleTestCase<SpaceAfterCommaRule> {
 
     @Test
     void testRuleProperties() {
@@ -288,7 +287,7 @@ class SpaceAfterCommaRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SpaceAfterCommaRule createRule() {
         new SpaceAfterCommaRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterForRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterForRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class SpaceAfterForRuleTest extends AbstractRuleTestCase {
+class SpaceAfterForRuleTest extends GenericAbstractRuleTestCase<SpaceAfterForRule> {
 
     private static final MESSAGE = 'The for keyword within class None is not followed by a single space'
 
@@ -69,7 +68,7 @@ class SpaceAfterForRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SpaceAfterForRule createRule() {
         new SpaceAfterForRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterIfRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterIfRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class SpaceAfterIfRuleTest extends AbstractRuleTestCase {
+class SpaceAfterIfRuleTest extends GenericAbstractRuleTestCase<SpaceAfterIfRule> {
 
     private static final MESSAGE = 'The if keyword within class None is not followed by a single space'
 
@@ -82,7 +81,7 @@ class SpaceAfterIfRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SpaceAfterIfRule createRule() {
         new SpaceAfterIfRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterOpeningBraceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterOpeningBraceRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class SpaceAfterOpeningBraceRuleTest extends AbstractRuleTestCase {
+class SpaceAfterOpeningBraceRuleTest extends GenericAbstractRuleTestCase<SpaceAfterOpeningBraceRule> {
 
     private static final String BLOCK_VIOLATION_MESSAGE = 'The opening brace for the block in class None is not followed by a space or whitespace'
 
@@ -324,7 +323,7 @@ c        '''
     }
 
     @Override
-    protected Rule createRule() {
+    protected SpaceAfterOpeningBraceRule createRule() {
         new SpaceAfterOpeningBraceRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterSemicolonRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterSemicolonRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class SpaceAfterSemicolonRuleTest extends AbstractRuleTestCase {
+class SpaceAfterSemicolonRuleTest extends GenericAbstractRuleTestCase<SpaceAfterSemicolonRule> {
 
     @Test
     void testRuleProperties() {
@@ -110,7 +109,7 @@ class SpaceAfterSemicolonRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SpaceAfterSemicolonRule createRule() {
         new SpaceAfterSemicolonRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterSwitchRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterSwitchRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class SpaceAfterSwitchRuleTest extends AbstractRuleTestCase {
+class SpaceAfterSwitchRuleTest extends GenericAbstractRuleTestCase<SpaceAfterSwitchRule> {
 
     private static final MESSAGE = 'The switch keyword within class None is not followed by a single space'
 
@@ -65,7 +64,7 @@ class SpaceAfterSwitchRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SpaceAfterSwitchRule createRule() {
         new SpaceAfterSwitchRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterWhileRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterWhileRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class SpaceAfterWhileRuleTest extends AbstractRuleTestCase {
+class SpaceAfterWhileRuleTest extends GenericAbstractRuleTestCase<SpaceAfterWhileRule> {
 
     private static final MESSAGE = 'The while keyword within class None is not followed by a single space'
 
@@ -71,7 +70,7 @@ class SpaceAfterWhileRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SpaceAfterWhileRule createRule() {
         new SpaceAfterWhileRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceAroundClosureArrowRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceAroundClosureArrowRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for SpaceAroundClosureArrowRule
  *
  * @author Chris Mair
  */
-class SpaceAroundClosureArrowRuleTest extends AbstractRuleTestCase {
+class SpaceAroundClosureArrowRuleTest extends GenericAbstractRuleTestCase<SpaceAroundClosureArrowRule> {
 
     @Test
     void testRuleProperties() {
@@ -79,7 +78,7 @@ class SpaceAroundClosureArrowRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SpaceAroundClosureArrowRule createRule() {
         new SpaceAroundClosureArrowRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceAroundMapEntryColonRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceAroundMapEntryColonRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for SpaceAroundMapEntryColonRule
  *
  * @author Chris Mair
  */
-class SpaceAroundMapEntryColonRuleTest extends AbstractRuleTestCase {
+class SpaceAroundMapEntryColonRuleTest extends GenericAbstractRuleTestCase<SpaceAroundMapEntryColonRule> {
 
     private static final PRECEDED = 'preceded'
     private static final FOLLOWED = 'followed'
@@ -118,7 +117,7 @@ class SpaceAroundMapEntryColonRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SpaceAroundMapEntryColonRule createRule() {
         new SpaceAroundMapEntryColonRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceAroundOperatorRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceAroundOperatorRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class SpaceAroundOperatorRuleTest extends AbstractRuleTestCase {
+class SpaceAroundOperatorRuleTest extends GenericAbstractRuleTestCase<SpaceAroundOperatorRule> {
 
     @Test
     void testRuleProperties() {
@@ -243,7 +242,7 @@ class SpaceAroundOperatorRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SpaceAroundOperatorRule createRule() {
         new SpaceAroundOperatorRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceBeforeClosingBraceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceBeforeClosingBraceRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class SpaceBeforeClosingBraceRuleTest extends AbstractRuleTestCase {
+class SpaceBeforeClosingBraceRuleTest extends GenericAbstractRuleTestCase<SpaceBeforeClosingBraceRule> {
 
     private static final String BLOCK_VIOLATION_MESSAGE = 'The closing brace for the block in class None is not preceded by a space or whitespace'
     private static final String CLOSURE_VIOLATION_MESSAGE = 'The closing brace for the closure in class None is not preceded by a space or whitespace'
@@ -267,7 +266,7 @@ c        '''
     }
 
     @Override
-    protected Rule createRule() {
+    protected SpaceBeforeClosingBraceRule createRule() {
         new SpaceBeforeClosingBraceRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceBeforeOpeningBraceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceBeforeOpeningBraceRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class SpaceBeforeOpeningBraceRuleTest extends AbstractRuleTestCase {
+class SpaceBeforeOpeningBraceRuleTest extends GenericAbstractRuleTestCase<SpaceBeforeOpeningBraceRule> {
 
     private static final String BLOCK_VIOLATION_MESSAGE = 'The opening brace for the block in class None is not preceded by a space or whitespace'
 
@@ -259,7 +258,7 @@ c        '''
     }
 
     @Override
-    protected Rule createRule() {
+    protected SpaceBeforeOpeningBraceRule createRule() {
         new SpaceBeforeOpeningBraceRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/TrailingWhitespaceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/TrailingWhitespaceRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.formatting
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Joe Sondow
  */
-class TrailingWhitespaceRuleTest extends AbstractRuleTestCase {
+class TrailingWhitespaceRuleTest extends GenericAbstractRuleTestCase<TrailingWhitespaceRule> {
 
     private static final String MESSAGE = 'Line ends with whitespace characters'
 
@@ -124,7 +123,7 @@ class TrailingWhitespaceRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected TrailingWhitespaceRule createRule() {
         new TrailingWhitespaceRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/generic/IllegalClassMemberRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/generic/IllegalClassMemberRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.generic
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for IllegalClassMemberRule
  *
  * @author Chris Mair
  */
-class IllegalClassMemberRuleTest extends AbstractRuleTestCase {
+class IllegalClassMemberRuleTest extends GenericAbstractRuleTestCase<IllegalClassMemberRule> {
 
     @Test
     void testRuleProperties() {
@@ -243,7 +242,7 @@ class IllegalClassMemberRuleTest extends AbstractRuleTestCase {
 //---------------
 
     @Override
-    protected Rule createRule() {
+    protected IllegalClassMemberRule createRule() {
         new IllegalClassMemberRule(applyToClassNames:'*')
     }
 }

--- a/src/test/groovy/org/codenarc/rule/generic/IllegalClassReferenceRule_MultipleClassNamesTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/generic/IllegalClassReferenceRule_MultipleClassNamesTest.groovy
@@ -16,7 +16,6 @@
 package org.codenarc.rule.generic
 
 import org.codenarc.rule.AbstractClassReferenceRuleTestCase
-import org.codenarc.rule.Rule
 
 /**
  * Tests for IllegalClassReferenceRule - checks for specifying a multiple, comma-separated class names for the classNames field
@@ -26,12 +25,12 @@ import org.codenarc.rule.Rule
  *
  * @author Chris Mair
  */
-class IllegalClassReferenceRule_MultipleClassNamesTest extends AbstractClassReferenceRuleTestCase {
+class IllegalClassReferenceRule_MultipleClassNamesTest extends AbstractClassReferenceRuleTestCase<IllegalClassReferenceRule> {
 
     final String className = 'com.example.MyExampleClass'
 
     @Override
-    protected Rule createRule() {
+    protected IllegalClassReferenceRule createRule() {
         new IllegalClassReferenceRule(classNames:'org.example.OtherClass,com.example.MyExampleClass, UnrelatedClass')
     }
 }

--- a/src/test/groovy/org/codenarc/rule/generic/IllegalClassReferenceRule_SingleClassNameTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/generic/IllegalClassReferenceRule_SingleClassNameTest.groovy
@@ -16,7 +16,6 @@
 package org.codenarc.rule.generic
 
 import org.codenarc.rule.AbstractClassReferenceRuleTestCase
-import org.codenarc.rule.Rule
 import org.junit.Test
 
 /**
@@ -27,7 +26,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class IllegalClassReferenceRule_SingleClassNameTest extends AbstractClassReferenceRuleTestCase {
+class IllegalClassReferenceRule_SingleClassNameTest extends AbstractClassReferenceRuleTestCase<IllegalClassReferenceRule> {
 
     final String className = 'com.example.MyExampleClass'
 
@@ -41,7 +40,7 @@ class IllegalClassReferenceRule_SingleClassNameTest extends AbstractClassReferen
     }
 
     @Override
-    protected Rule createRule() {
+    protected IllegalClassReferenceRule createRule() {
         new IllegalClassReferenceRule(classNames:'com.example.MyExampleClass')
     }
 }

--- a/src/test/groovy/org/codenarc/rule/generic/IllegalClassReferenceRule_WildcardsClassNamesTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/generic/IllegalClassReferenceRule_WildcardsClassNamesTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.generic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -27,7 +26,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class IllegalClassReferenceRule_WildcardsClassNamesTest extends AbstractRuleTestCase {
+class IllegalClassReferenceRule_WildcardsClassNamesTest extends GenericAbstractRuleTestCase<IllegalClassReferenceRule> {
 
     // Just test proper handling of wildcards by this rule. Assume that the other IllegalClassReferenceRule_*Test
     // classes sufficiently test references across the possible language constructs.
@@ -62,7 +61,7 @@ class IllegalClassReferenceRule_WildcardsClassNamesTest extends AbstractRuleTest
     }
 
     @Override
-    protected Rule createRule() {
+    protected IllegalClassReferenceRule createRule() {
         new IllegalClassReferenceRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/generic/IllegalPackageReferenceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/generic/IllegalPackageReferenceRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.generic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class IllegalPackageReferenceRuleTest extends AbstractRuleTestCase {
+class IllegalPackageReferenceRuleTest extends GenericAbstractRuleTestCase<IllegalPackageReferenceRule> {
 
     @Test
     void testRuleProperties() {
@@ -297,7 +296,7 @@ class IllegalPackageReferenceRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected IllegalPackageReferenceRule createRule() {
         new IllegalPackageReferenceRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/generic/IllegalRegexRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/generic/IllegalRegexRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.generic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class IllegalRegexRuleTest extends AbstractRuleTestCase {
+class IllegalRegexRuleTest extends GenericAbstractRuleTestCase<IllegalRegexRule> {
 
     private static final REGEX = /\@author Joe/
 
@@ -87,7 +86,7 @@ class IllegalRegexRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected IllegalRegexRule createRule() {
         new IllegalRegexRule(regex:REGEX)
     }
 

--- a/src/test/groovy/org/codenarc/rule/generic/IllegalStringRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/generic/IllegalStringRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.generic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class IllegalStringRuleTest extends AbstractRuleTestCase {
+class IllegalStringRuleTest extends GenericAbstractRuleTestCase<IllegalStringRule> {
 
     private static final TEXT = '@author Joe'
 
@@ -63,7 +62,7 @@ class IllegalStringRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected IllegalStringRule createRule() {
         new IllegalStringRule(string:TEXT)
     }
 }

--- a/src/test/groovy/org/codenarc/rule/generic/IllegalSubclassRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/generic/IllegalSubclassRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.generic
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for IllegalSubclassRule
  *
  * @author Chris Mair
  */
-class IllegalSubclassRuleTest extends AbstractRuleTestCase {
+class IllegalSubclassRuleTest extends GenericAbstractRuleTestCase<IllegalSubclassRule> {
 
     @Test
     void testRuleProperties() {
@@ -79,7 +78,7 @@ class IllegalSubclassRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected IllegalSubclassRule createRule() {
         new IllegalSubclassRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/generic/RequiredRegexRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/generic/RequiredRegexRuleTest.groovy
@@ -15,18 +15,17 @@
  */
 package org.codenarc.rule.generic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
-import org.junit.Test
-
 import static org.codenarc.test.TestUtil.containsAll
+
+import org.codenarc.rule.GenericAbstractRuleTestCase
+import org.junit.Test
 
 /**
  * Tests for RequiredRegexRule
  *
  * @author Chris Mair
   */
-class RequiredRegexRuleTest extends AbstractRuleTestCase {
+class RequiredRegexRuleTest extends GenericAbstractRuleTestCase<RequiredRegexRule> {
 
     static skipTestThatUnrelatedCodeHasNoViolations
     static skipTestThatInvalidCodeHasNoViolations
@@ -68,7 +67,7 @@ class RequiredRegexRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected RequiredRegexRule createRule() {
         new RequiredRegexRule(regex:REGEX)
     }
 

--- a/src/test/groovy/org/codenarc/rule/generic/RequiredStringRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/generic/RequiredStringRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.generic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class RequiredStringRuleTest extends AbstractRuleTestCase {
+class RequiredStringRuleTest extends GenericAbstractRuleTestCase<RequiredStringRule> {
 
     static skipTestThatUnrelatedCodeHasNoViolations
     static skipTestThatInvalidCodeHasNoViolations
@@ -66,7 +65,7 @@ class RequiredStringRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected RequiredStringRule createRule() {
         new RequiredStringRule(string:TEXT)
     }
 

--- a/src/test/groovy/org/codenarc/rule/generic/StatelessClassRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/generic/StatelessClassRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.generic
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Before
 import org.junit.Test
 
@@ -25,7 +24,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class StatelessClassRuleTest extends AbstractRuleTestCase {
+class StatelessClassRuleTest extends GenericAbstractRuleTestCase<StatelessClassRule> {
 
     @Test
     void testRuleProperties() {
@@ -246,7 +245,7 @@ class StatelessClassRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected StatelessClassRule createRule() {
         new StatelessClassRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/grails/GrailsDomainHasEqualsRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/grails/GrailsDomainHasEqualsRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.grails
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Hamlet D'Arcy
  * @author Chris Mair
   */
-class GrailsDomainHasEqualsRuleTest extends AbstractRuleTestCase {
+class GrailsDomainHasEqualsRuleTest extends GenericAbstractRuleTestCase<GrailsDomainHasEqualsRule> {
 
     @Test
     void testRuleProperties() {
@@ -79,7 +78,7 @@ class GrailsDomainHasEqualsRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected GrailsDomainHasEqualsRule createRule() {
         new GrailsDomainHasEqualsRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/grails/GrailsDomainHasToStringRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/grails/GrailsDomainHasToStringRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.grails
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Hamlet D'Arcy
  * @author Chris Mair
   */
-class GrailsDomainHasToStringRuleTest extends AbstractRuleTestCase {
+class GrailsDomainHasToStringRuleTest extends GenericAbstractRuleTestCase<GrailsDomainHasToStringRule> {
 
     @Test
     void testRuleProperties() {
@@ -79,7 +78,7 @@ class GrailsDomainHasToStringRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected GrailsDomainHasToStringRule createRule() {
         new GrailsDomainHasToStringRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/grails/GrailsDomainReservedSqlKeywordNameRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/grails/GrailsDomainReservedSqlKeywordNameRuleTest.groovy
@@ -15,17 +15,16 @@
  */
 package org.codenarc.rule.grails
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Before
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for GrailsDomainReservedSqlKeywordNameRule
  *
  * @author Artur Gajowy
  */
-class GrailsDomainReservedSqlKeywordNameRuleTest extends AbstractRuleTestCase {
+class GrailsDomainReservedSqlKeywordNameRuleTest extends GenericAbstractRuleTestCase<GrailsDomainReservedSqlKeywordNameRule> {
 
     @Before
     void setup() {
@@ -154,7 +153,7 @@ class GrailsDomainReservedSqlKeywordNameRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected GrailsDomainReservedSqlKeywordNameRule createRule() {
         new GrailsDomainReservedSqlKeywordNameRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/grails/GrailsDomainWithServiceReferenceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/grails/GrailsDomainWithServiceReferenceRuleTest.groovy
@@ -15,17 +15,16 @@
  */
 package org.codenarc.rule.grails
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Before
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for GrailsDomainWithServiceReferenceRule
  *
  * @author Artur Gajowy
  */
-class GrailsDomainWithServiceReferenceRuleTest extends AbstractRuleTestCase {
+class GrailsDomainWithServiceReferenceRuleTest extends GenericAbstractRuleTestCase<GrailsDomainWithServiceReferenceRule> {
 
     @Test
     void testRuleProperties() {
@@ -90,7 +89,7 @@ class GrailsDomainWithServiceReferenceRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected GrailsDomainWithServiceReferenceRule createRule() {
         new GrailsDomainWithServiceReferenceRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/grails/GrailsDuplicateConstraintRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/grails/GrailsDuplicateConstraintRuleTest.groovy
@@ -15,17 +15,16 @@
  */
 package org.codenarc.rule.grails
 
-import org.codenarc.rule.Rule
-import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Before
+import org.junit.Test
 
 /**
  * Tests for GrailsDuplicateConstraintRule
  *
  * @author Chris Mair
  */
-class GrailsDuplicateConstraintRuleTest extends AbstractRuleTestCase {
+class GrailsDuplicateConstraintRuleTest extends GenericAbstractRuleTestCase<GrailsDuplicateConstraintRule> {
 
     @Test
     void testRuleProperties() {
@@ -192,7 +191,7 @@ class GrailsDuplicateConstraintRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected GrailsDuplicateConstraintRule createRule() {
         new GrailsDuplicateConstraintRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/grails/GrailsDuplicateMappingRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/grails/GrailsDuplicateMappingRuleTest.groovy
@@ -15,17 +15,16 @@
  */
 package org.codenarc.rule.grails
 
-import org.codenarc.rule.Rule
-import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Before
+import org.junit.Test
 
 /**
  * Tests for GrailsDuplicateMappingRule
  *
  * @author Chris Mair
  */
-class GrailsDuplicateMappingRuleTest extends AbstractRuleTestCase {
+class GrailsDuplicateMappingRuleTest extends GenericAbstractRuleTestCase<GrailsDuplicateMappingRule> {
 
     @Test
     void testRuleProperties() {
@@ -169,7 +168,7 @@ class GrailsDuplicateMappingRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected GrailsDuplicateMappingRule createRule() {
         new GrailsDuplicateMappingRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/grails/GrailsMassAssignmentRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/grails/GrailsMassAssignmentRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.grails
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for GrailsMassAssignmentRule
  *
  * @author Brian Soby
  */
-class GrailsMassAssignmentRuleTest extends AbstractRuleTestCase {
+class GrailsMassAssignmentRuleTest extends GenericAbstractRuleTestCase<GrailsMassAssignmentRule> {
 
     @Test
     void testRuleProperties() {
@@ -130,7 +129,7 @@ class GrailsMassAssignmentRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected GrailsMassAssignmentRule createRule() {
         new GrailsMassAssignmentRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/grails/GrailsPublicControllerMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/grails/GrailsPublicControllerMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.grails
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Before
 import org.junit.Test
 
@@ -25,7 +24,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class GrailsPublicControllerMethodRuleTest extends AbstractRuleTestCase {
+class GrailsPublicControllerMethodRuleTest extends GenericAbstractRuleTestCase<GrailsPublicControllerMethodRule> {
 
     private static final CONTROLLER_PATH = 'project/MyProject/grails-app/controllers/com/xxx/MyController.groovy'
     private static final OTHER_PATH = 'project/MyProject/src/groovy/MyHelper.groovy'
@@ -165,7 +164,7 @@ class GrailsPublicControllerMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected GrailsPublicControllerMethodRule createRule() {
         new GrailsPublicControllerMethodRule(enabled:true)
     }
 }

--- a/src/test/groovy/org/codenarc/rule/grails/GrailsServletContextReferenceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/grails/GrailsServletContextReferenceRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.grails
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Before
 import org.junit.Test
 
@@ -25,7 +24,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class GrailsServletContextReferenceRuleTest extends AbstractRuleTestCase {
+class GrailsServletContextReferenceRuleTest extends GenericAbstractRuleTestCase<GrailsServletContextReferenceRule> {
 
     private static final CONTROLLER_PATH = 'project/MyProject/grails-app/controllers/com/xxx/MyController.groovy'
     private static final TAGLIB_PATH = 'project/MyProject/grails-app/taglib/MyTagLib.groovy'
@@ -118,7 +117,7 @@ class GrailsServletContextReferenceRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected GrailsServletContextReferenceRule createRule() {
         new GrailsServletContextReferenceRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/grails/GrailsStatelessServiceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/grails/GrailsStatelessServiceRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.grails
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Before
 import org.junit.Test
 
@@ -25,7 +24,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class GrailsStatelessServiceRuleTest extends AbstractRuleTestCase {
+class GrailsStatelessServiceRuleTest extends GenericAbstractRuleTestCase<GrailsStatelessServiceRule> {
 
     private static final SERVICE_PATH = 'project/MyProject/grails-app/services/com/xxx/MyService.groovy'
     private static final OTHER_PATH = 'project/MyProject/src/groovy/MyHelper.groovy'
@@ -245,7 +244,7 @@ class GrailsStatelessServiceRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected GrailsStatelessServiceRule createRule() {
         new GrailsStatelessServiceRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/AssignCollectionSortRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/AssignCollectionSortRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Hamlet D'Arcy
  * @author Chris Mair
  */
-class AssignCollectionSortRuleTest extends AbstractRuleTestCase {
+class AssignCollectionSortRuleTest extends GenericAbstractRuleTestCase<AssignCollectionSortRule> {
 
     @Test
     void testRuleProperties() {
@@ -129,7 +128,7 @@ class AssignCollectionSortRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected AssignCollectionSortRule createRule() {
         new AssignCollectionSortRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/AssignCollectionUniqueRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/AssignCollectionUniqueRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -27,7 +26,7 @@ import org.junit.Test
  * @author Jon DeJong
  *
  */
-class AssignCollectionUniqueRuleTest extends AbstractRuleTestCase {
+class AssignCollectionUniqueRuleTest extends GenericAbstractRuleTestCase<AssignCollectionUniqueRule> {
 
     @Test
     void testRuleProperties() {
@@ -75,7 +74,7 @@ class AssignCollectionUniqueRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected AssignCollectionUniqueRule createRule() {
         new AssignCollectionUniqueRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ClosureAsLastMethodParameterRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ClosureAsLastMethodParameterRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Marcin Erdmann
  */
-class ClosureAsLastMethodParameterRuleTest extends AbstractRuleTestCase {
+class ClosureAsLastMethodParameterRuleTest extends GenericAbstractRuleTestCase<ClosureAsLastMethodParameterRule> {
 
     @Test
     void testRuleProperties() {
@@ -228,7 +227,7 @@ class ClosureAsLastMethodParameterRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ClosureAsLastMethodParameterRule createRule() {
         new ClosureAsLastMethodParameterRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/CollectAllIsDeprecatedRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/CollectAllIsDeprecatedRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Joachim Baumann
  */
-class CollectAllIsDeprecatedRuleTest extends AbstractRuleTestCase {
+class CollectAllIsDeprecatedRuleTest extends GenericAbstractRuleTestCase<CollectAllIsDeprecatedRule> {
 
     @Test
     void testRuleProperties() {
@@ -55,7 +54,7 @@ class CollectAllIsDeprecatedRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected CollectAllIsDeprecatedRule createRule() {
         new CollectAllIsDeprecatedRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ConfusingMultipleReturnsRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ConfusingMultipleReturnsRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ConfusingMultipleReturnsRuleTest extends AbstractRuleTestCase {
+class ConfusingMultipleReturnsRuleTest extends GenericAbstractRuleTestCase<ConfusingMultipleReturnsRule> {
 
     @Test
     void testRuleProperties() {
@@ -73,7 +72,7 @@ class ConfusingMultipleReturnsRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ConfusingMultipleReturnsRule createRule() {
         new ConfusingMultipleReturnsRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ExplicitArrayListInstantiationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ExplicitArrayListInstantiationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ExplicitArrayListInstantiationRuleTest extends AbstractRuleTestCase {
+class ExplicitArrayListInstantiationRuleTest extends GenericAbstractRuleTestCase<ExplicitArrayListInstantiationRule> {
 
     @Test
     void testRuleProperties() {
@@ -81,7 +80,7 @@ class ExplicitArrayListInstantiationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitArrayListInstantiationRule createRule() {
         new ExplicitArrayListInstantiationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToAndMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToAndMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ExplicitCallToAndMethodRuleTest extends AbstractRuleTestCase {
+class ExplicitCallToAndMethodRuleTest extends GenericAbstractRuleTestCase<ExplicitCallToAndMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -52,7 +51,7 @@ class ExplicitCallToAndMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitCallToAndMethodRule createRule() {
         new ExplicitCallToAndMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToCompareToMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToCompareToMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ExplicitCallToCompareToMethodRuleTest extends AbstractRuleTestCase {
+class ExplicitCallToCompareToMethodRuleTest extends GenericAbstractRuleTestCase<ExplicitCallToCompareToMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -58,7 +57,7 @@ class ExplicitCallToCompareToMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitCallToCompareToMethodRule createRule() {
         new ExplicitCallToCompareToMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToDivMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToDivMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ExplicitCallToDivMethodRuleTest extends AbstractRuleTestCase {
+class ExplicitCallToDivMethodRuleTest extends GenericAbstractRuleTestCase<ExplicitCallToDivMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -53,7 +52,7 @@ class ExplicitCallToDivMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitCallToDivMethodRule createRule() {
         new ExplicitCallToDivMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToEqualsMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToEqualsMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ExplicitCallToEqualsMethodRuleTest extends AbstractRuleTestCase {
+class ExplicitCallToEqualsMethodRuleTest extends GenericAbstractRuleTestCase<ExplicitCallToEqualsMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -55,7 +54,7 @@ class ExplicitCallToEqualsMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitCallToEqualsMethodRule createRule() {
         new ExplicitCallToEqualsMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToGetAtMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToGetAtMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ExplicitCallToGetAtMethodRuleTest extends AbstractRuleTestCase {
+class ExplicitCallToGetAtMethodRuleTest extends GenericAbstractRuleTestCase<ExplicitCallToGetAtMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -53,7 +52,7 @@ class ExplicitCallToGetAtMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitCallToGetAtMethodRule createRule() {
         new ExplicitCallToGetAtMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToLeftShiftMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToLeftShiftMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ExplicitCallToLeftShiftMethodRuleTest extends AbstractRuleTestCase {
+class ExplicitCallToLeftShiftMethodRuleTest extends GenericAbstractRuleTestCase<ExplicitCallToLeftShiftMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -53,7 +52,7 @@ class ExplicitCallToLeftShiftMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitCallToLeftShiftMethodRule createRule() {
         new ExplicitCallToLeftShiftMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToMinusMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToMinusMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ExplicitCallToMinusMethodRuleTest extends AbstractRuleTestCase {
+class ExplicitCallToMinusMethodRuleTest extends GenericAbstractRuleTestCase<ExplicitCallToMinusMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -53,7 +52,7 @@ class ExplicitCallToMinusMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitCallToMinusMethodRule createRule() {
         new ExplicitCallToMinusMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToModMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToModMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ExplicitCallToModMethodRuleTest extends AbstractRuleTestCase {
+class ExplicitCallToModMethodRuleTest extends GenericAbstractRuleTestCase<ExplicitCallToModMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -53,7 +52,7 @@ class ExplicitCallToModMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitCallToModMethodRule createRule() {
         new ExplicitCallToModMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToMultiplyMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToMultiplyMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ExplicitCallToMultiplyMethodRuleTest extends AbstractRuleTestCase {
+class ExplicitCallToMultiplyMethodRuleTest extends GenericAbstractRuleTestCase<ExplicitCallToMultiplyMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -54,7 +53,7 @@ class ExplicitCallToMultiplyMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitCallToMultiplyMethodRule createRule() {
         new ExplicitCallToMultiplyMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToOrMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToOrMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ExplicitCallToOrMethodRuleTest extends AbstractRuleTestCase {
+class ExplicitCallToOrMethodRuleTest extends GenericAbstractRuleTestCase<ExplicitCallToOrMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -52,7 +51,7 @@ class ExplicitCallToOrMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitCallToOrMethodRule createRule() {
         new ExplicitCallToOrMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToPlusMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToPlusMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ExplicitCallToPlusMethodRuleTest extends AbstractRuleTestCase {
+class ExplicitCallToPlusMethodRuleTest extends GenericAbstractRuleTestCase<ExplicitCallToPlusMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -63,7 +62,7 @@ class ExplicitCallToPlusMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitCallToPlusMethodRule createRule() {
         new ExplicitCallToPlusMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToPowerMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToPowerMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ExplicitCallToPowerMethodRuleTest extends AbstractRuleTestCase {
+class ExplicitCallToPowerMethodRuleTest extends GenericAbstractRuleTestCase<ExplicitCallToPowerMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -53,7 +52,7 @@ class ExplicitCallToPowerMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitCallToPowerMethodRule createRule() {
         new ExplicitCallToPowerMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToRightShiftMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToRightShiftMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ExplicitCallToRightShiftMethodRuleTest extends AbstractRuleTestCase {
+class ExplicitCallToRightShiftMethodRuleTest extends GenericAbstractRuleTestCase<ExplicitCallToRightShiftMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -53,7 +52,7 @@ class ExplicitCallToRightShiftMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitCallToRightShiftMethodRule createRule() {
         new ExplicitCallToRightShiftMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToXorMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ExplicitCallToXorMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ExplicitCallToXorMethodRuleTest extends AbstractRuleTestCase {
+class ExplicitCallToXorMethodRuleTest extends GenericAbstractRuleTestCase<ExplicitCallToXorMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -53,7 +52,7 @@ class ExplicitCallToXorMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitCallToXorMethodRule createRule() {
         new ExplicitCallToXorMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ExplicitHashMapInstantiationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ExplicitHashMapInstantiationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ExplicitHashMapInstantiationRuleTest extends AbstractRuleTestCase {
+class ExplicitHashMapInstantiationRuleTest extends GenericAbstractRuleTestCase<ExplicitHashMapInstantiationRule> {
 
     @Test
     void testRuleProperties() {
@@ -81,7 +80,7 @@ class ExplicitHashMapInstantiationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitHashMapInstantiationRule createRule() {
         new ExplicitHashMapInstantiationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ExplicitHashSetInstantiationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ExplicitHashSetInstantiationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ExplicitHashSetInstantiationRuleTest extends AbstractRuleTestCase {
+class ExplicitHashSetInstantiationRuleTest extends GenericAbstractRuleTestCase<ExplicitHashSetInstantiationRule> {
 
     @Test
     void testRuleProperties() {
@@ -81,7 +80,7 @@ class ExplicitHashSetInstantiationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitHashSetInstantiationRule createRule() {
         new ExplicitHashSetInstantiationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ExplicitLinkedHashMapInstantiationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ExplicitLinkedHashMapInstantiationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author René Scheibe
  */
-class ExplicitLinkedHashMapInstantiationRuleTest extends AbstractRuleTestCase {
+class ExplicitLinkedHashMapInstantiationRuleTest extends GenericAbstractRuleTestCase<ExplicitLinkedHashMapInstantiationRule> {
 
     @Test
     void testRuleProperties() {
@@ -81,7 +80,7 @@ class ExplicitLinkedHashMapInstantiationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitLinkedHashMapInstantiationRule createRule() {
         new ExplicitLinkedHashMapInstantiationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ExplicitLinkedListInstantiationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ExplicitLinkedListInstantiationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Hamlet D'Arcy
  * @author Chris Mair
  */
-class ExplicitLinkedListInstantiationRuleTest extends AbstractRuleTestCase {
+class ExplicitLinkedListInstantiationRuleTest extends GenericAbstractRuleTestCase<ExplicitLinkedListInstantiationRule> {
 
     @Test
     void testRuleProperties() {
@@ -82,7 +81,7 @@ class ExplicitLinkedListInstantiationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitLinkedListInstantiationRule createRule() {
         new ExplicitLinkedListInstantiationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ExplicitStackInstantiationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ExplicitStackInstantiationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Hamlet D'Arcy
  * @author Chris Mair
  */
-class ExplicitStackInstantiationRuleTest extends AbstractRuleTestCase {
+class ExplicitStackInstantiationRuleTest extends GenericAbstractRuleTestCase<ExplicitStackInstantiationRule> {
 
     @Test
     void testRuleProperties() {
@@ -82,7 +81,7 @@ class ExplicitStackInstantiationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitStackInstantiationRule createRule() {
         new ExplicitStackInstantiationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/ExplicitTreeSetInstantiationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/ExplicitTreeSetInstantiationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Hamlet D'Arcy
  * @author Chris Mair
  */
-class ExplicitTreeSetInstantiationRuleTest extends AbstractRuleTestCase {
+class ExplicitTreeSetInstantiationRuleTest extends GenericAbstractRuleTestCase<ExplicitTreeSetInstantiationRule> {
 
     @Test
     void testRuleProperties() {
@@ -82,7 +81,7 @@ class ExplicitTreeSetInstantiationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ExplicitTreeSetInstantiationRule createRule() {
         new ExplicitTreeSetInstantiationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/GStringAsMapKeyRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/GStringAsMapKeyRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author @Hackergarten
  */
-class GStringAsMapKeyRuleTest extends AbstractRuleTestCase {
+class GStringAsMapKeyRuleTest extends GenericAbstractRuleTestCase<GStringAsMapKeyRule> {
 
     @Test
     void testRuleProperties() {
@@ -72,7 +71,7 @@ class GStringAsMapKeyRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected GStringAsMapKeyRule createRule() {
         new GStringAsMapKeyRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/groovyism/GStringExpressionWithinStringRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/GStringExpressionWithinStringRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for GStringExpressionWithinStringRule
  *
  * @author Chris Mair
  */
-class GStringExpressionWithinStringRuleTest extends AbstractRuleTestCase {
+class GStringExpressionWithinStringRuleTest extends GenericAbstractRuleTestCase<GStringExpressionWithinStringRule> {
 
     @Test
     void testRuleProperties() {
@@ -163,7 +162,7 @@ class GStringExpressionWithinStringRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected GStringExpressionWithinStringRule createRule() {
         new GStringExpressionWithinStringRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/GetterMethodCouldBePropertyRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/GetterMethodCouldBePropertyRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Hamlet D'Arcy
  * @author Chris Mair
  */
-class GetterMethodCouldBePropertyRuleTest extends AbstractRuleTestCase {
+class GetterMethodCouldBePropertyRuleTest extends GenericAbstractRuleTestCase<GetterMethodCouldBePropertyRule> {
 
     @Test
     void testRuleProperties() {
@@ -279,7 +278,7 @@ class GetterMethodCouldBePropertyRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected GetterMethodCouldBePropertyRule createRule() {
         new GetterMethodCouldBePropertyRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/GroovyLangImmutableRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/GroovyLangImmutableRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class GroovyLangImmutableRuleTest extends AbstractRuleTestCase {
+class GroovyLangImmutableRuleTest extends GenericAbstractRuleTestCase<GroovyLangImmutableRule> {
 
     @Test
     void testRuleProperties() {
@@ -119,7 +118,7 @@ class GroovyLangImmutableRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected GroovyLangImmutableRule createRule() {
         new GroovyLangImmutableRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/UseCollectManyRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/UseCollectManyRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Joachim Baumann
  */
-class UseCollectManyRuleTest extends AbstractRuleTestCase {
+class UseCollectManyRuleTest extends GenericAbstractRuleTestCase<UseCollectManyRule> {
 
     @Test
     void testRuleProperties() {
@@ -55,7 +54,7 @@ class UseCollectManyRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UseCollectManyRule createRule() {
         new UseCollectManyRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/groovyism/UseCollectNestedRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/groovyism/UseCollectNestedRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.groovyism
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Joachim Baumann
  * @author Chris Mair
  */
-class UseCollectNestedRuleTest extends AbstractRuleTestCase {
+class UseCollectNestedRuleTest extends GenericAbstractRuleTestCase<UseCollectNestedRule> {
 
     @Test
     void testRuleProperties() {
@@ -82,7 +81,7 @@ class UseCollectNestedRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UseCollectNestedRule createRule() {
         new UseCollectNestedRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/imports/DuplicateImportRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/imports/DuplicateImportRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.imports
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class DuplicateImportRuleTest extends AbstractRuleTestCase {
+class DuplicateImportRuleTest extends GenericAbstractRuleTestCase<DuplicateImportRule> {
 
     @Test
     void testRuleProperties() {
@@ -121,7 +120,7 @@ class DuplicateImportRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected DuplicateImportRule createRule() {
         new DuplicateImportRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/imports/ImportFromSamePackageRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/imports/ImportFromSamePackageRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.imports
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class ImportFromSamePackageRuleTest extends AbstractRuleTestCase {
+class ImportFromSamePackageRuleTest extends GenericAbstractRuleTestCase<ImportFromSamePackageRule> {
 
     @Test
     void testRuleProperties() {
@@ -83,7 +82,7 @@ class ImportFromSamePackageRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ImportFromSamePackageRule createRule() {
         new ImportFromSamePackageRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/imports/ImportFromSunPackagesRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/imports/ImportFromSunPackagesRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.imports
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class ImportFromSunPackagesRuleTest extends AbstractRuleTestCase {
+class ImportFromSunPackagesRuleTest extends GenericAbstractRuleTestCase<ImportFromSunPackagesRule> {
 
     @Test
     void testRuleProperties() {
@@ -65,7 +64,7 @@ class ImportFromSunPackagesRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ImportFromSunPackagesRule createRule() {
         new ImportFromSunPackagesRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/imports/MisorderedStaticImportsRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/imports/MisorderedStaticImportsRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.imports
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Erik Pragt
  * @author Marcin Erdmann
   */
-class MisorderedStaticImportsRuleTest extends AbstractRuleTestCase {
+class MisorderedStaticImportsRuleTest extends GenericAbstractRuleTestCase<MisorderedStaticImportsRule> {
 
     @Test
     void testRuleProperties() {
@@ -116,7 +115,7 @@ class MisorderedStaticImportsRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected MisorderedStaticImportsRule createRule() {
         new MisorderedStaticImportsRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/imports/NoWildcardImportsRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/imports/NoWildcardImportsRuleTest.groovy
@@ -15,9 +15,8 @@
  */
 package org.codenarc.rule.imports
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for NoWildcardImportsRule
@@ -25,7 +24,7 @@ import org.codenarc.rule.AbstractRuleTestCase
  * @author Kyle Boon
  * @author Chris Mair
  */
-class NoWildcardImportsRuleTest extends AbstractRuleTestCase {
+class NoWildcardImportsRuleTest extends GenericAbstractRuleTestCase<NoWildcardImportsRule> {
 
     @Test
     void testRuleProperties() {
@@ -75,7 +74,7 @@ class NoWildcardImportsRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected NoWildcardImportsRule createRule() {
         new NoWildcardImportsRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/imports/UnnecessaryGroovyImportRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/imports/UnnecessaryGroovyImportRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.imports
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class UnnecessaryGroovyImportRuleTest extends AbstractRuleTestCase {
+class UnnecessaryGroovyImportRuleTest extends GenericAbstractRuleTestCase<UnnecessaryGroovyImportRule> {
 
     @Test
     void testRuleProperties() {
@@ -181,7 +180,7 @@ class UnnecessaryGroovyImportRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryGroovyImportRule createRule() {
         new UnnecessaryGroovyImportRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/imports/UnusedImportRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/imports/UnusedImportRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.imports
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class UnusedImportRuleTest extends AbstractRuleTestCase {
+class UnusedImportRuleTest extends GenericAbstractRuleTestCase<UnusedImportRule> {
 
     @Test
     void testRuleProperties() {
@@ -222,7 +221,7 @@ Other$.value()
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnusedImportRule createRule() {
         new UnusedImportRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/jdbc/DirectConnectionManagementRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/jdbc/DirectConnectionManagementRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.jdbc
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class DirectConnectionManagementRuleTest extends AbstractRuleTestCase {
+class DirectConnectionManagementRuleTest extends GenericAbstractRuleTestCase<DirectConnectionManagementRule> {
 
     @Test
     void testRuleProperties() {
@@ -53,7 +52,7 @@ class DirectConnectionManagementRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected DirectConnectionManagementRule createRule() {
         new DirectConnectionManagementRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/jdbc/JdbcConnectionReferenceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/jdbc/JdbcConnectionReferenceRuleTest.groovy
@@ -16,7 +16,6 @@
 package org.codenarc.rule.jdbc
 
 import org.codenarc.rule.AbstractClassReferenceRuleTestCase
-import org.codenarc.rule.Rule
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class JdbcConnectionReferenceRuleTest extends AbstractClassReferenceRuleTestCase {
+class JdbcConnectionReferenceRuleTest extends AbstractClassReferenceRuleTestCase<JdbcConnectionReferenceRule> {
 
     final String className = 'java.sql.Connection'
 
@@ -35,7 +34,7 @@ class JdbcConnectionReferenceRuleTest extends AbstractClassReferenceRuleTestCase
     }
 
     @Override
-    protected Rule createRule() {
+    protected JdbcConnectionReferenceRule createRule() {
         new JdbcConnectionReferenceRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/jdbc/JdbcResultSetReferenceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/jdbc/JdbcResultSetReferenceRuleTest.groovy
@@ -16,7 +16,6 @@
 package org.codenarc.rule.jdbc
 
 import org.codenarc.rule.AbstractClassReferenceRuleTestCase
-import org.codenarc.rule.Rule
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class JdbcResultSetReferenceRuleTest extends AbstractClassReferenceRuleTestCase {
+class JdbcResultSetReferenceRuleTest extends AbstractClassReferenceRuleTestCase<JdbcResultSetReferenceRule> {
 
     final String className = 'java.sql.ResultSet'
 
@@ -35,7 +34,7 @@ class JdbcResultSetReferenceRuleTest extends AbstractClassReferenceRuleTestCase 
     }
 
     @Override
-    protected Rule createRule() {
+    protected JdbcResultSetReferenceRule createRule() {
         new JdbcResultSetReferenceRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/jdbc/JdbcStatementReferenceRule_CallableStatementTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/jdbc/JdbcStatementReferenceRule_CallableStatementTest.groovy
@@ -16,19 +16,18 @@
 package org.codenarc.rule.jdbc
 
 import org.codenarc.rule.AbstractClassReferenceRuleTestCase
-import org.codenarc.rule.Rule
 
 /**
  * Tests for JdbcStatementReferenceRule - checks for references to java.sql.CallableStatement
  *
  * @author Chris Mair
  */
-class JdbcStatementReferenceRule_CallableStatementTest extends AbstractClassReferenceRuleTestCase {
+class JdbcStatementReferenceRule_CallableStatementTest extends AbstractClassReferenceRuleTestCase<JdbcStatementReferenceRule> {
 
     final String className = 'java.sql.CallableStatement'
 
     @Override
-    protected Rule createRule() {
+    protected JdbcStatementReferenceRule createRule() {
         new JdbcStatementReferenceRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/jdbc/JdbcStatementReferenceRule_PreparedStatementTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/jdbc/JdbcStatementReferenceRule_PreparedStatementTest.groovy
@@ -16,19 +16,18 @@
 package org.codenarc.rule.jdbc
 
 import org.codenarc.rule.AbstractClassReferenceRuleTestCase
-import org.codenarc.rule.Rule
 
 /**
  * Tests for JdbcStatementReferenceRule - checks for references to java.sql.PreparedStatement
  *
  * @author Chris Mair
  */
-class JdbcStatementReferenceRule_PreparedStatementTest extends AbstractClassReferenceRuleTestCase {
+class JdbcStatementReferenceRule_PreparedStatementTest extends AbstractClassReferenceRuleTestCase<JdbcStatementReferenceRule> {
 
     final String className = 'java.sql.PreparedStatement'
 
     @Override
-    protected Rule createRule() {
+    protected JdbcStatementReferenceRule createRule() {
         new JdbcStatementReferenceRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/jdbc/JdbcStatementReferenceRule_StatementTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/jdbc/JdbcStatementReferenceRule_StatementTest.groovy
@@ -16,7 +16,6 @@
 package org.codenarc.rule.jdbc
 
 import org.codenarc.rule.AbstractClassReferenceRuleTestCase
-import org.codenarc.rule.Rule
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class JdbcStatementReferenceRule_StatementTest extends AbstractClassReferenceRuleTestCase {
+class JdbcStatementReferenceRule_StatementTest extends AbstractClassReferenceRuleTestCase<JdbcStatementReferenceRule> {
 
     final String className = 'java.sql.Statement'
 
@@ -46,7 +45,7 @@ class JdbcStatementReferenceRule_StatementTest extends AbstractClassReferenceRul
     }
 
     @Override
-    protected Rule createRule() {
+    protected JdbcStatementReferenceRule createRule() {
         new JdbcStatementReferenceRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/ChainedTestRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/ChainedTestRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class ChainedTestRuleTest extends AbstractRuleTestCase {
+class ChainedTestRuleTest extends GenericAbstractRuleTestCase<ChainedTestRule> {
 
     @Test
     void testRuleProperties() {
@@ -95,7 +94,7 @@ class ChainedTestRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ChainedTestRule createRule() {
         new ChainedTestRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/CoupledTestCaseRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/CoupledTestCaseRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author 'Hamlet D'Arcy'
   */
-class CoupledTestCaseRuleTest extends AbstractRuleTestCase {
+class CoupledTestCaseRuleTest extends GenericAbstractRuleTestCase<CoupledTestCaseRule> {
 
     @Test
     void testRuleProperties() {
@@ -100,7 +99,7 @@ class CoupledTestCaseRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected CoupledTestCaseRule createRule() {
         new CoupledTestCaseRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/JUnitAssertAlwaysFailsRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/JUnitAssertAlwaysFailsRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class JUnitAssertAlwaysFailsRuleTest extends AbstractRuleTestCase {
+class JUnitAssertAlwaysFailsRuleTest extends GenericAbstractRuleTestCase<JUnitAssertAlwaysFailsRule> {
 
     @Test
     void testRuleProperties() {
@@ -323,7 +322,7 @@ class JUnitAssertAlwaysFailsRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected JUnitAssertAlwaysFailsRule createRule() {
         new JUnitAssertAlwaysFailsRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/JUnitAssertAlwaysSucceedsRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/JUnitAssertAlwaysSucceedsRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class JUnitAssertAlwaysSucceedsRuleTest extends AbstractRuleTestCase {
+class JUnitAssertAlwaysSucceedsRuleTest extends GenericAbstractRuleTestCase<JUnitAssertAlwaysSucceedsRule> {
 
     @Test
     void testRuleProperties() {
@@ -303,7 +302,7 @@ class JUnitAssertAlwaysSucceedsRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected JUnitAssertAlwaysSucceedsRule createRule() {
         new JUnitAssertAlwaysSucceedsRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/JUnitAssertEqualsConstantActualValueRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/JUnitAssertEqualsConstantActualValueRuleTest.groovy
@@ -15,17 +15,16 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Before
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for JUnitAssertEqualsConstantActualValueRule
  *
  * @author Artur Gajowy
  */
-class JUnitAssertEqualsConstantActualValueRuleTest extends AbstractRuleTestCase {
+class JUnitAssertEqualsConstantActualValueRuleTest extends GenericAbstractRuleTestCase<JUnitAssertEqualsConstantActualValueRule> {
 
     @Before
     void setup() {
@@ -110,7 +109,7 @@ class JUnitAssertEqualsConstantActualValueRuleTest extends AbstractRuleTestCase 
         'Most likely it was intended to be the `expected` value.'
 
     @Override
-    protected Rule createRule() {
+    protected JUnitAssertEqualsConstantActualValueRule createRule() {
         new JUnitAssertEqualsConstantActualValueRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/JUnitFailWithoutMessageRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/JUnitFailWithoutMessageRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class JUnitFailWithoutMessageRuleTest extends AbstractRuleTestCase {
+class JUnitFailWithoutMessageRuleTest extends GenericAbstractRuleTestCase<JUnitFailWithoutMessageRule> {
 
     @Test
     void testRuleProperties() {
@@ -64,7 +63,7 @@ class JUnitFailWithoutMessageRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected JUnitFailWithoutMessageRule createRule() {
         new JUnitFailWithoutMessageRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/JUnitLostTestRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/JUnitLostTestRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class JUnitLostTestRuleTest extends AbstractRuleTestCase {
+class JUnitLostTestRuleTest extends GenericAbstractRuleTestCase<JUnitLostTestRule> {
 
     @Test
     void testRuleProperties() {
@@ -126,7 +125,7 @@ class JUnitLostTestRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected JUnitLostTestRule createRule() {
         new JUnitLostTestRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/JUnitPublicFieldRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/JUnitPublicFieldRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for JUnitPublicFieldRule
  *
  * @author Chris Mair
  */
-class JUnitPublicFieldRuleTest extends AbstractRuleTestCase {
+class JUnitPublicFieldRuleTest extends GenericAbstractRuleTestCase<JUnitPublicFieldRule> {
 
     @Test
     void testRuleProperties() {
@@ -98,7 +97,7 @@ class JUnitPublicFieldRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected JUnitPublicFieldRule createRule() {
         new JUnitPublicFieldRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/JUnitPublicNonTestMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/JUnitPublicNonTestMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class JUnitPublicNonTestMethodRuleTest extends AbstractRuleTestCase {
+class JUnitPublicNonTestMethodRuleTest extends GenericAbstractRuleTestCase<JUnitPublicNonTestMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -221,7 +220,7 @@ class JUnitPublicNonTestMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected JUnitPublicNonTestMethodRule createRule() {
         new JUnitPublicNonTestMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/JUnitPublicPropertyRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/JUnitPublicPropertyRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for JUnitPublicPropertyRule
  *
  * @author Chris Mair
  */
-class JUnitPublicPropertyRuleTest extends AbstractRuleTestCase {
+class JUnitPublicPropertyRuleTest extends GenericAbstractRuleTestCase<JUnitPublicPropertyRule> {
 
     @Test
     void testRuleProperties() {
@@ -91,7 +90,7 @@ class JUnitPublicPropertyRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected JUnitPublicPropertyRule createRule() {
         new JUnitPublicPropertyRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/JUnitSetUpCallsSuperRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/JUnitSetUpCallsSuperRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class JUnitSetUpCallsSuperRuleTest extends AbstractRuleTestCase {
+class JUnitSetUpCallsSuperRuleTest extends GenericAbstractRuleTestCase<JUnitSetUpCallsSuperRule> {
 
     @Test
     void testRuleProperties() {
@@ -166,7 +165,7 @@ class JUnitSetUpCallsSuperRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected JUnitSetUpCallsSuperRule createRule() {
         new JUnitSetUpCallsSuperRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/JUnitStyleAssertionsRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/JUnitStyleAssertionsRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class JUnitStyleAssertionsRuleTest extends AbstractRuleTestCase {
+class JUnitStyleAssertionsRuleTest extends GenericAbstractRuleTestCase<JUnitStyleAssertionsRule> {
 
     @Test
     void testRuleProperties() {
@@ -219,7 +218,7 @@ class JUnitStyleAssertionsRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected JUnitStyleAssertionsRule createRule() {
         new JUnitStyleAssertionsRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/JUnitTearDownCallsSuperRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/JUnitTearDownCallsSuperRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class JUnitTearDownCallsSuperRuleTest extends AbstractRuleTestCase {
+class JUnitTearDownCallsSuperRuleTest extends GenericAbstractRuleTestCase<JUnitTearDownCallsSuperRule> {
 
     @Test
     void testRuleProperties() {
@@ -162,7 +161,7 @@ class JUnitTearDownCallsSuperRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected JUnitTearDownCallsSuperRule createRule() {
         new JUnitTearDownCallsSuperRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/JUnitTestMethodWithoutAssertRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/JUnitTestMethodWithoutAssertRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class JUnitTestMethodWithoutAssertRuleTest extends AbstractRuleTestCase {
+class JUnitTestMethodWithoutAssertRuleTest extends GenericAbstractRuleTestCase<JUnitTestMethodWithoutAssertRule> {
 
     @Test
     void testRuleProperties() {
@@ -187,7 +186,7 @@ class JUnitTestMethodWithoutAssertRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected JUnitTestMethodWithoutAssertRule createRule() {
         new JUnitTestMethodWithoutAssertRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/JUnitUnnecessarySetUpRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/JUnitUnnecessarySetUpRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class JUnitUnnecessarySetUpRuleTest extends AbstractRuleTestCase {
+class JUnitUnnecessarySetUpRuleTest extends GenericAbstractRuleTestCase<JUnitUnnecessarySetUpRule> {
 
     @Test
     void testRuleProperties() {
@@ -140,7 +139,7 @@ class JUnitUnnecessarySetUpRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected JUnitUnnecessarySetUpRule createRule() {
         new JUnitUnnecessarySetUpRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/JUnitUnnecessaryTearDownRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/JUnitUnnecessaryTearDownRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class JUnitUnnecessaryTearDownRuleTest extends AbstractRuleTestCase {
+class JUnitUnnecessaryTearDownRuleTest extends GenericAbstractRuleTestCase<JUnitUnnecessaryTearDownRule> {
 
     @Test
     void testRuleProperties() {
@@ -140,7 +139,7 @@ class JUnitUnnecessaryTearDownRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected JUnitUnnecessaryTearDownRule createRule() {
         new JUnitUnnecessaryTearDownRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/JUnitUnnecessaryThrowsExceptionRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/JUnitUnnecessaryThrowsExceptionRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for JUnitUnnecessaryThrowsExceptionRule
  *
  * @author Chris Mair
  */
-class JUnitUnnecessaryThrowsExceptionRuleTest extends AbstractRuleTestCase {
+class JUnitUnnecessaryThrowsExceptionRuleTest extends GenericAbstractRuleTestCase<JUnitUnnecessaryThrowsExceptionRule> {
 
     @Test
     void testRuleProperties() {
@@ -182,7 +181,7 @@ class JUnitUnnecessaryThrowsExceptionRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected JUnitUnnecessaryThrowsExceptionRule createRule() {
         new JUnitUnnecessaryThrowsExceptionRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/SpockIgnoreRestUsedRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/SpockIgnoreRestUsedRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Jan Ahrens
  * @auther Stefan Armbruster
   */
-class SpockIgnoreRestUsedRuleTest extends AbstractRuleTestCase {
+class SpockIgnoreRestUsedRuleTest extends GenericAbstractRuleTestCase<SpockIgnoreRestUsedRule> {
 
     @Test
     void testRuleProperties() {
@@ -162,7 +161,7 @@ class SpockIgnoreRestUsedRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SpockIgnoreRestUsedRule createRule() {
         new SpockIgnoreRestUsedRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/UnnecessaryFailRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/UnnecessaryFailRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryFailRuleTest extends AbstractRuleTestCase {
+class UnnecessaryFailRuleTest extends GenericAbstractRuleTestCase<UnnecessaryFailRule> {
 
     @Test
     void testRuleProperties() {
@@ -162,7 +161,7 @@ class UnnecessaryFailRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryFailRule createRule() {
         new UnnecessaryFailRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/UseAssertEqualsInsteadOfAssertTrueRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/UseAssertEqualsInsteadOfAssertTrueRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Per Junel
  * @author Hamlet D'Arcy
   */
-class UseAssertEqualsInsteadOfAssertTrueRuleTest extends AbstractRuleTestCase {
+class UseAssertEqualsInsteadOfAssertTrueRuleTest extends GenericAbstractRuleTestCase<UseAssertEqualsInsteadOfAssertTrueRule> {
 
     @Test
     void testRuleProperties() {
@@ -88,7 +87,7 @@ class UseAssertEqualsInsteadOfAssertTrueRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UseAssertEqualsInsteadOfAssertTrueRule createRule() {
         new UseAssertEqualsInsteadOfAssertTrueRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/UseAssertFalseInsteadOfNegationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/UseAssertFalseInsteadOfNegationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author 'Hamlet D'Arcy'
   */
-class UseAssertFalseInsteadOfNegationRuleTest extends AbstractRuleTestCase {
+class UseAssertFalseInsteadOfNegationRuleTest extends GenericAbstractRuleTestCase<UseAssertFalseInsteadOfNegationRule> {
 
     @Test
     void testRuleProperties() {
@@ -72,7 +71,7 @@ class UseAssertFalseInsteadOfNegationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UseAssertFalseInsteadOfNegationRule createRule() {
         new UseAssertFalseInsteadOfNegationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/UseAssertNullInsteadOfAssertEqualsRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/UseAssertNullInsteadOfAssertEqualsRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UseAssertNullInsteadOfAssertEqualsRuleTest extends AbstractRuleTestCase {
+class UseAssertNullInsteadOfAssertEqualsRuleTest extends GenericAbstractRuleTestCase<UseAssertNullInsteadOfAssertEqualsRule> {
 
     @Test
     void testRuleProperties() {
@@ -80,7 +79,7 @@ class UseAssertNullInsteadOfAssertEqualsRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UseAssertNullInsteadOfAssertEqualsRule createRule() {
         new UseAssertNullInsteadOfAssertEqualsRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/UseAssertSameInsteadOfAssertTrueRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/UseAssertSameInsteadOfAssertTrueRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UseAssertSameInsteadOfAssertTrueRuleTest extends AbstractRuleTestCase {
+class UseAssertSameInsteadOfAssertTrueRuleTest extends GenericAbstractRuleTestCase<UseAssertSameInsteadOfAssertTrueRule> {
 
     @Test
     void testRuleProperties() {
@@ -84,7 +83,7 @@ class UseAssertSameInsteadOfAssertTrueRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UseAssertSameInsteadOfAssertTrueRule createRule() {
         new UseAssertSameInsteadOfAssertTrueRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/UseAssertTrueInsteadOfAssertEqualsRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/UseAssertTrueInsteadOfAssertEqualsRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UseAssertTrueInsteadOfAssertEqualsRuleTest extends AbstractRuleTestCase {
+class UseAssertTrueInsteadOfAssertEqualsRuleTest extends GenericAbstractRuleTestCase<UseAssertTrueInsteadOfAssertEqualsRule> {
 
     @Test
     void testRuleProperties() {
@@ -169,7 +168,7 @@ class UseAssertTrueInsteadOfAssertEqualsRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UseAssertTrueInsteadOfAssertEqualsRule createRule() {
         new UseAssertTrueInsteadOfAssertEqualsRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/junit/UseAssertTrueInsteadOfNegationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/UseAssertTrueInsteadOfNegationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.junit
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author 'Hamlet D'Arcy'
   */
-class UseAssertTrueInsteadOfNegationRuleTest extends AbstractRuleTestCase {
+class UseAssertTrueInsteadOfNegationRuleTest extends GenericAbstractRuleTestCase<UseAssertTrueInsteadOfNegationRule> {
 
     @Test
     void testRuleProperties() {
@@ -72,7 +71,7 @@ class UseAssertTrueInsteadOfNegationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UseAssertTrueInsteadOfNegationRule createRule() {
         new UseAssertTrueInsteadOfNegationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/logging/LoggerForDifferentClassRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/logging/LoggerForDifferentClassRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.logging
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class LoggerForDifferentClassRuleTest extends AbstractRuleTestCase {
+class LoggerForDifferentClassRuleTest extends GenericAbstractRuleTestCase<LoggerForDifferentClassRule> {
 
     @Test
     void testRuleProperties() {
@@ -328,7 +327,7 @@ class LoggerForDifferentClassRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected LoggerForDifferentClassRule createRule() {
         new LoggerForDifferentClassRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/logging/LoggerWithWrongModifiersRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/logging/LoggerWithWrongModifiersRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.logging
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class LoggerWithWrongModifiersRuleTest extends AbstractRuleTestCase {
+class LoggerWithWrongModifiersRuleTest extends GenericAbstractRuleTestCase<LoggerWithWrongModifiersRule> {
 
     @Test
     void testRuleProperties() {
@@ -184,7 +183,7 @@ class LoggerWithWrongModifiersRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected LoggerWithWrongModifiersRule createRule() {
         new LoggerWithWrongModifiersRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/logging/LoggingSwallowsStacktraceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/logging/LoggingSwallowsStacktraceRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.logging
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author 'Hamlet D'Arcy'
   */
-class LoggingSwallowsStacktraceRuleTest extends AbstractRuleTestCase {
+class LoggingSwallowsStacktraceRuleTest extends GenericAbstractRuleTestCase<LoggingSwallowsStacktraceRule> {
 
     @Test
     void testRuleProperties() {
@@ -93,7 +92,7 @@ class LoggingSwallowsStacktraceRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected LoggingSwallowsStacktraceRule createRule() {
         new LoggingSwallowsStacktraceRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/logging/MultipleLoggersRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/logging/MultipleLoggersRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.logging
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author 'Hamlet D'Arcy'
   */
-class MultipleLoggersRuleTest extends AbstractRuleTestCase {
+class MultipleLoggersRuleTest extends GenericAbstractRuleTestCase<MultipleLoggersRule> {
 
     @Test
     void testRuleProperties() {
@@ -75,7 +74,7 @@ class MultipleLoggersRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected MultipleLoggersRule createRule() {
         new MultipleLoggersRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/logging/PrintStackTraceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/logging/PrintStackTraceRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.logging
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class PrintStackTraceRuleTest extends AbstractRuleTestCase {
+class PrintStackTraceRuleTest extends GenericAbstractRuleTestCase<PrintStackTraceRule> {
 
     @Test
     void testRuleProperties() {
@@ -109,7 +108,7 @@ class PrintStackTraceRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected PrintStackTraceRule createRule() {
         new PrintStackTraceRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/logging/PrintlnRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/logging/PrintlnRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.logging
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class PrintlnRuleTest extends AbstractRuleTestCase {
+class PrintlnRuleTest extends GenericAbstractRuleTestCase<PrintlnRule> {
 
     @Test
     void testRuleProperties() {
@@ -203,7 +202,7 @@ class PrintlnRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected PrintlnRule createRule() {
         new PrintlnRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/logging/SystemErrPrintRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/logging/SystemErrPrintRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.logging
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class SystemErrPrintRuleTest extends AbstractRuleTestCase {
+class SystemErrPrintRuleTest extends GenericAbstractRuleTestCase<SystemErrPrintRule> {
 
     @Test
     void testRuleProperties() {
@@ -97,7 +96,7 @@ class SystemErrPrintRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SystemErrPrintRule createRule() {
         new SystemErrPrintRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/logging/SystemOutPrintRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/logging/SystemOutPrintRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.logging
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class SystemOutPrintRuleTest extends AbstractRuleTestCase {
+class SystemOutPrintRuleTest extends GenericAbstractRuleTestCase<SystemOutPrintRule> {
 
     @Test
     void testRuleProperties() {
@@ -97,7 +96,7 @@ class SystemOutPrintRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SystemOutPrintRule createRule() {
         new SystemOutPrintRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/naming/AbstractClassNameRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/naming/AbstractClassNameRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.naming
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class AbstractClassNameRuleTest extends AbstractRuleTestCase {
+class AbstractClassNameRuleTest extends GenericAbstractRuleTestCase<AbstractClassNameRule> {
 
     @Test
     void testRuleProperties() {
@@ -90,7 +89,7 @@ class AbstractClassNameRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected AbstractClassNameRule createRule() {
         new AbstractClassNameRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/naming/ClassNameRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/naming/ClassNameRuleTest.groovy
@@ -15,18 +15,17 @@
  */
 package org.codenarc.rule.naming
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
-import org.junit.Test
-
 import static org.codenarc.test.TestUtil.shouldFailWithMessageContaining
+
+import org.codenarc.rule.GenericAbstractRuleTestCase
+import org.junit.Test
 
 /**
  * Tests for ClassNameRule
  *
  * @author Chris Mair
   */
-class ClassNameRuleTest extends AbstractRuleTestCase {
+class ClassNameRuleTest extends GenericAbstractRuleTestCase<ClassNameRule> {
 
     @Test
     void testRuleProperties() {
@@ -131,7 +130,7 @@ class ClassNameRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ClassNameRule createRule() {
         new ClassNameRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/naming/ClassNameSameAsFilenameRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/naming/ClassNameSameAsFilenameRuleTest.groovy
@@ -15,10 +15,9 @@
  */
 package org.codenarc.rule.naming
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Before
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for ClassNameSameAsFilenameRule
@@ -26,7 +25,7 @@ import org.codenarc.rule.AbstractRuleTestCase
  * @author Artur Gajowy
  * @author Chris Mair
  */
-class ClassNameSameAsFilenameRuleTest extends AbstractRuleTestCase {
+class ClassNameSameAsFilenameRuleTest extends GenericAbstractRuleTestCase<ClassNameSameAsFilenameRule> {
 
     static skipTestThatUnrelatedCodeHasNoViolations
 
@@ -122,7 +121,7 @@ class ClassNameSameAsFilenameRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ClassNameSameAsFilenameRule createRule() {
         new ClassNameSameAsFilenameRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/naming/ClassNameSameAsSuperclassRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/naming/ClassNameSameAsSuperclassRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.naming
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class ClassNameSameAsSuperclassRuleTest extends AbstractRuleTestCase {
+class ClassNameSameAsSuperclassRuleTest extends GenericAbstractRuleTestCase<ClassNameSameAsSuperclassRule> {
 
     @Test
     void testRuleProperties() {
@@ -80,7 +79,7 @@ class ClassNameSameAsSuperclassRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ClassNameSameAsSuperclassRule createRule() {
         new ClassNameSameAsSuperclassRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/naming/ConfusingMethodNameRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/naming/ConfusingMethodNameRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.naming
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Hamlet D'Arcy
  * @author Hubert 'Mr. Haki' Klein Ikkink
   */
-class ConfusingMethodNameRuleTest extends AbstractRuleTestCase {
+class ConfusingMethodNameRuleTest extends GenericAbstractRuleTestCase<ConfusingMethodNameRule> {
 
     @Test
     void testRuleProperties() {
@@ -201,7 +200,7 @@ class ConfusingMethodNameRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ConfusingMethodNameRule createRule() {
         new ConfusingMethodNameRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/naming/FactoryMethodNameRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/naming/FactoryMethodNameRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.naming
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class FactoryMethodNameRuleTest extends AbstractRuleTestCase {
+class FactoryMethodNameRuleTest extends GenericAbstractRuleTestCase<FactoryMethodNameRule> {
 
     @Test
     void testRuleProperties() {
@@ -124,7 +123,7 @@ class FactoryMethodNameRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected FactoryMethodNameRule createRule() {
         new FactoryMethodNameRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/naming/FieldNameRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/naming/FieldNameRuleTest.groovy
@@ -15,18 +15,17 @@
  */
 package org.codenarc.rule.naming
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
-import org.junit.Test
-
 import static org.codenarc.test.TestUtil.shouldFailWithMessageContaining
+
+import org.codenarc.rule.GenericAbstractRuleTestCase
+import org.junit.Test
 
 /**
  * Tests for FieldNameRule
  *
  * @author Chris Mair
   */
-class FieldNameRuleTest extends AbstractRuleTestCase {
+class FieldNameRuleTest extends GenericAbstractRuleTestCase<FieldNameRule> {
 
     @Test
     void testRuleProperties() {
@@ -335,7 +334,7 @@ class FieldNameRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected FieldNameRule createRule() {
         new FieldNameRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/naming/InterfaceNameRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/naming/InterfaceNameRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.naming
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class InterfaceNameRuleTest extends AbstractRuleTestCase {
+class InterfaceNameRuleTest extends GenericAbstractRuleTestCase<InterfaceNameRule> {
 
     @Test
     void testRuleProperties() {
@@ -90,7 +89,7 @@ class InterfaceNameRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected InterfaceNameRule createRule() {
         new InterfaceNameRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/naming/InterfaceNameSameAsSuperInterfaceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/naming/InterfaceNameSameAsSuperInterfaceRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.naming
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class InterfaceNameSameAsSuperInterfaceRuleTest extends AbstractRuleTestCase {
+class InterfaceNameSameAsSuperInterfaceRuleTest extends GenericAbstractRuleTestCase<InterfaceNameSameAsSuperInterfaceRule> {
 
     @Test
     void testRuleProperties() {
@@ -70,7 +69,7 @@ class InterfaceNameSameAsSuperInterfaceRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected InterfaceNameSameAsSuperInterfaceRule createRule() {
         new InterfaceNameSameAsSuperInterfaceRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/naming/MethodNameRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/naming/MethodNameRuleTest.groovy
@@ -15,18 +15,17 @@
  */
 package org.codenarc.rule.naming
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
-import org.junit.Test
-
 import static org.codenarc.test.TestUtil.shouldFailWithMessageContaining
+
+import org.codenarc.rule.GenericAbstractRuleTestCase
+import org.junit.Test
 
 /**
  * Tests for MethodNameRule
  *
  * @author Chris Mair
   */
-class MethodNameRuleTest extends AbstractRuleTestCase {
+class MethodNameRuleTest extends GenericAbstractRuleTestCase<MethodNameRule> {
 
     @Test
     void testRuleProperties() {
@@ -166,7 +165,7 @@ class MethodNameRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected MethodNameRule createRule() {
         new MethodNameRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/naming/ObjectOverrideMisspelledMethodNameRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/naming/ObjectOverrideMisspelledMethodNameRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.naming
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author @Hackergarten
  */
-class ObjectOverrideMisspelledMethodNameRuleTest extends AbstractRuleTestCase {
+class ObjectOverrideMisspelledMethodNameRuleTest extends GenericAbstractRuleTestCase<ObjectOverrideMisspelledMethodNameRule> {
 
     @Test
     void testRuleProperties() {
@@ -93,7 +92,7 @@ class ObjectOverrideMisspelledMethodNameRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ObjectOverrideMisspelledMethodNameRule createRule() {
         new ObjectOverrideMisspelledMethodNameRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/naming/PackageNameMatchesFilePathRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/naming/PackageNameMatchesFilePathRuleTest.groovy
@@ -15,17 +15,16 @@
  */
 package org.codenarc.rule.naming
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Before
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for PackageMismatchesFilepathRule
  *
  * @author Simon Tost
  */
-class PackageNameMatchesFilePathRuleTest extends AbstractRuleTestCase {
+class PackageNameMatchesFilePathRuleTest extends GenericAbstractRuleTestCase<PackageNameMatchesFilePathRule> {
 
     @Before
     void setup() {
@@ -192,7 +191,7 @@ class PackageNameMatchesFilePathRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected PackageNameMatchesFilePathRule createRule() {
         new PackageNameMatchesFilePathRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/naming/PackageNameRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/naming/PackageNameRuleTest.groovy
@@ -15,18 +15,17 @@
  */
 package org.codenarc.rule.naming
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
-import org.junit.Test
-
 import static org.codenarc.test.TestUtil.shouldFailWithMessageContaining
+
+import org.codenarc.rule.GenericAbstractRuleTestCase
+import org.junit.Test
 
 /**
  * Tests for PackageNameRule
  *
  * @author Chris Mair
   */
-class PackageNameRuleTest extends AbstractRuleTestCase {
+class PackageNameRuleTest extends GenericAbstractRuleTestCase<PackageNameRule> {
 
     @Test
     void testRuleProperties() {
@@ -134,7 +133,7 @@ class PackageNameRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected PackageNameRule createRule() {
         new PackageNameRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/naming/ParameterNameRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/naming/ParameterNameRuleTest.groovy
@@ -15,18 +15,17 @@
  */
 package org.codenarc.rule.naming
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
-import org.junit.Test
-
 import static org.codenarc.test.TestUtil.shouldFailWithMessageContaining
+
+import org.codenarc.rule.GenericAbstractRuleTestCase
+import org.junit.Test
 
 /**
  * Tests for ParameterNameRule
  *
  * @author Chris Mair
   */
-class ParameterNameRuleTest extends AbstractRuleTestCase {
+class ParameterNameRuleTest extends GenericAbstractRuleTestCase<ParameterNameRule> {
 
     @Test
     void testRuleProperties() {
@@ -195,7 +194,7 @@ class ParameterNameRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ParameterNameRule createRule() {
         new ParameterNameRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/naming/PropertyNameRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/naming/PropertyNameRuleTest.groovy
@@ -15,18 +15,17 @@
  */
 package org.codenarc.rule.naming
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
-import org.junit.Test
-
 import static org.codenarc.test.TestUtil.shouldFailWithMessageContaining
+
+import org.codenarc.rule.GenericAbstractRuleTestCase
+import org.junit.Test
 
 /**
  * Tests for PropertyNameRule
  *
  * @author Chris Mair
   */
-class PropertyNameRuleTest extends AbstractRuleTestCase {
+class PropertyNameRuleTest extends GenericAbstractRuleTestCase<PropertyNameRule> {
 
     @Test
     void testRuleProperties() {
@@ -297,7 +296,7 @@ class PropertyNameRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected PropertyNameRule createRule() {
         new PropertyNameRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/naming/VariableNameRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/naming/VariableNameRuleTest.groovy
@@ -15,18 +15,17 @@
  */
 package org.codenarc.rule.naming
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
-import org.junit.Test
-
 import static org.codenarc.test.TestUtil.shouldFailWithMessageContaining
+
+import org.codenarc.rule.GenericAbstractRuleTestCase
+import org.junit.Test
 
 /**
  * Tests for VariableNameRule
  *
  * @author Chris Mair
   */
-class VariableNameRuleTest extends AbstractRuleTestCase {
+class VariableNameRuleTest extends GenericAbstractRuleTestCase<VariableNameRule> {
 
     @Test
     void testRuleProperties() {
@@ -322,7 +321,7 @@ class VariableNameRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected VariableNameRule createRule() {
         new VariableNameRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/security/FileCreateTempFileRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/security/FileCreateTempFileRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.security
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class FileCreateTempFileRuleTest extends AbstractRuleTestCase {
+class FileCreateTempFileRuleTest extends GenericAbstractRuleTestCase<FileCreateTempFileRule> {
 
     @Test
     void testRuleProperties() {
@@ -93,7 +92,7 @@ class FileCreateTempFileRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected FileCreateTempFileRule createRule() {
         new FileCreateTempFileRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/security/InsecureRandomRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/security/InsecureRandomRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.security
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class InsecureRandomRuleTest extends AbstractRuleTestCase {
+class InsecureRandomRuleTest extends GenericAbstractRuleTestCase<InsecureRandomRule> {
 
     @Test
     void testRuleProperties() {
@@ -64,7 +63,7 @@ class InsecureRandomRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected InsecureRandomRule createRule() {
         new InsecureRandomRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/security/JavaIoPackageAccessRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/security/JavaIoPackageAccessRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.security
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author 'Hamlet D'Arcy'
   */
-class JavaIoPackageAccessRuleTest extends AbstractRuleTestCase {
+class JavaIoPackageAccessRuleTest extends GenericAbstractRuleTestCase<JavaIoPackageAccessRule> {
 
     @Test
     void testRuleProperties() {
@@ -105,7 +104,7 @@ class JavaIoPackageAccessRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected JavaIoPackageAccessRule createRule() {
         new JavaIoPackageAccessRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/security/NonFinalPublicFieldRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/security/NonFinalPublicFieldRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.security
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author 'Hamlet D'Arcy'
   */
-class NonFinalPublicFieldRuleTest extends AbstractRuleTestCase {
+class NonFinalPublicFieldRuleTest extends GenericAbstractRuleTestCase<NonFinalPublicFieldRule> {
 
     @Test
     void testRuleProperties() {
@@ -54,7 +53,7 @@ class NonFinalPublicFieldRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected NonFinalPublicFieldRule createRule() {
         new NonFinalPublicFieldRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/security/NonFinalSubclassOfSensitiveInterfaceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/security/NonFinalSubclassOfSensitiveInterfaceRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.security
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class NonFinalSubclassOfSensitiveInterfaceRuleTest extends AbstractRuleTestCase {
+class NonFinalSubclassOfSensitiveInterfaceRuleTest extends GenericAbstractRuleTestCase<NonFinalSubclassOfSensitiveInterfaceRule> {
 
     @Test
     void testRuleProperties() {
@@ -146,7 +145,7 @@ class NonFinalSubclassOfSensitiveInterfaceRuleTest extends AbstractRuleTestCase 
     }
 
     @Override
-    protected Rule createRule() {
+    protected NonFinalSubclassOfSensitiveInterfaceRule createRule() {
         new NonFinalSubclassOfSensitiveInterfaceRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/security/ObjectFinalizeRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/security/ObjectFinalizeRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.security
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class ObjectFinalizeRuleTest extends AbstractRuleTestCase {
+class ObjectFinalizeRuleTest extends GenericAbstractRuleTestCase<ObjectFinalizeRule> {
 
     @Test
     void testRuleProperties() {
@@ -91,7 +90,7 @@ class ObjectFinalizeRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ObjectFinalizeRule createRule() {
         new ObjectFinalizeRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/security/PublicFinalizeMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/security/PublicFinalizeMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.security
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class PublicFinalizeMethodRuleTest extends AbstractRuleTestCase {
+class PublicFinalizeMethodRuleTest extends GenericAbstractRuleTestCase<PublicFinalizeMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -67,7 +66,7 @@ class PublicFinalizeMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected PublicFinalizeMethodRule createRule() {
         new PublicFinalizeMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/security/SystemExitRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/security/SystemExitRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.security
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class SystemExitRuleTest extends AbstractRuleTestCase {
+class SystemExitRuleTest extends GenericAbstractRuleTestCase<SystemExitRule> {
 
     @Test
     void testRuleProperties() {
@@ -93,7 +92,7 @@ class SystemExitRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SystemExitRule createRule() {
         new SystemExitRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/security/UnsafeArrayDeclarationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/security/UnsafeArrayDeclarationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.security
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnsafeArrayDeclarationRuleTest extends AbstractRuleTestCase {
+class UnsafeArrayDeclarationRuleTest extends GenericAbstractRuleTestCase<UnsafeArrayDeclarationRule> {
 
     @Test
     void testRuleProperties() {
@@ -66,7 +65,7 @@ class UnsafeArrayDeclarationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnsafeArrayDeclarationRule createRule() {
         new UnsafeArrayDeclarationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/security/UnsafeImplementationAsMapRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/security/UnsafeImplementationAsMapRuleTest.groovy
@@ -15,17 +15,16 @@
  */
 package org.codenarc.rule.security
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Before
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for UnsafeImplementationAsMapRule
  *
  * @author Artur Gajowy
  */
-class UnsafeImplementationAsMapRuleTest extends AbstractRuleTestCase {
+class UnsafeImplementationAsMapRuleTest extends GenericAbstractRuleTestCase<UnsafeImplementationAsMapRule> {
 
     private static final SOURCE_WITH_SINGLE_VIOLATION = """
         [nextElement: {}] as Enumeration      ${violation('java.util.Enumeration', 'hasMoreElements')}
@@ -100,7 +99,7 @@ class UnsafeImplementationAsMapRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnsafeImplementationAsMapRule createRule() {
         new UnsafeImplementationAsMapRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/serialization/EnumCustomSerializationIgnoredRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/serialization/EnumCustomSerializationIgnoredRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.serialization
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for EnumCustomSerializationIgnoredRule
  *
  * @author Chris Mair
  */
-class EnumCustomSerializationIgnoredRuleTest extends AbstractRuleTestCase {
+class EnumCustomSerializationIgnoredRuleTest extends GenericAbstractRuleTestCase<EnumCustomSerializationIgnoredRule> {
 
     @Test
     void testRuleProperties() {
@@ -101,7 +100,7 @@ class EnumCustomSerializationIgnoredRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected EnumCustomSerializationIgnoredRule createRule() {
         new EnumCustomSerializationIgnoredRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/serialization/SerialPersistentFieldsRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/serialization/SerialPersistentFieldsRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.serialization
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author 'Hamlet D'Arcy'
   */
-class SerialPersistentFieldsRuleTest extends AbstractRuleTestCase {
+class SerialPersistentFieldsRuleTest extends GenericAbstractRuleTestCase<SerialPersistentFieldsRule> {
 
     @Test
     void testRuleProperties() {
@@ -116,7 +115,7 @@ class SerialPersistentFieldsRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SerialPersistentFieldsRule createRule() {
         new SerialPersistentFieldsRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/serialization/SerialVersionUIDRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/serialization/SerialVersionUIDRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.serialization
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Hamlet D'Arcy
  * @author Chris Mair
  */
-class SerialVersionUIDRuleTest extends AbstractRuleTestCase {
+class SerialVersionUIDRuleTest extends GenericAbstractRuleTestCase<SerialVersionUIDRule> {
 
     @Test
     void testRuleProperties() {
@@ -95,7 +94,7 @@ class SerialVersionUIDRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected SerialVersionUIDRule createRule() {
         new SerialVersionUIDRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/serialization/SerializableClassMustDefineSerialVersionUIDRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/serialization/SerializableClassMustDefineSerialVersionUIDRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.serialization
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class SerializableClassMustDefineSerialVersionUIDRuleTest extends AbstractRuleTestCase {
+class SerializableClassMustDefineSerialVersionUIDRuleTest extends GenericAbstractRuleTestCase<SerializableClassMustDefineSerialVersionUIDRule> {
 
     @Test
     void testRuleProperties() {
@@ -104,7 +103,7 @@ class SerializableClassMustDefineSerialVersionUIDRuleTest extends AbstractRuleTe
     }
 
     @Override
-    protected Rule createRule() {
+    protected SerializableClassMustDefineSerialVersionUIDRule createRule() {
         new SerializableClassMustDefineSerialVersionUIDRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/size/AbcMetricRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/size/AbcMetricRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.size
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class AbcMetricRuleTest extends AbstractRuleTestCase {
+class AbcMetricRuleTest extends GenericAbstractRuleTestCase<AbcMetricRule> {
 
     @Test
     void testRuleProperties() {
@@ -241,7 +240,7 @@ class AbcMetricRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected AbcMetricRule createRule() {
         new AbcMetricRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/size/ClassSizeRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/size/ClassSizeRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.size
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class ClassSizeRuleTest extends AbstractRuleTestCase {
+class ClassSizeRuleTest extends GenericAbstractRuleTestCase<ClassSizeRule> {
 
     @Test
     void testRuleProperties() {
@@ -82,7 +81,7 @@ class ClassSizeRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ClassSizeRule createRule() {
         new ClassSizeRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/size/CrapMetricRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/size/CrapMetricRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.size
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class CrapMetricRuleTest extends AbstractRuleTestCase {
+class CrapMetricRuleTest extends GenericAbstractRuleTestCase<CrapMetricRule> {
 
     private static final String COBERTURA_FILE = 'coverage/Cobertura-example.xml'
     private static final BigDecimal CRAP_SCORE = 6.0
@@ -244,7 +243,7 @@ class CrapMetricRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected CrapMetricRule createRule() {
         new CrapMetricRule(coberturaXmlFile:COBERTURA_FILE)
     }
 

--- a/src/test/groovy/org/codenarc/rule/size/CyclomaticComplexityRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/size/CyclomaticComplexityRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.size
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class CyclomaticComplexityRuleTest extends AbstractRuleTestCase {
+class CyclomaticComplexityRuleTest extends GenericAbstractRuleTestCase<CyclomaticComplexityRule> {
 
     @Test
     void testRuleProperties() {
@@ -300,7 +299,7 @@ class CyclomaticComplexityRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected CyclomaticComplexityRule createRule() {
         new CyclomaticComplexityRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/size/MethodCountRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/size/MethodCountRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.size
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author 'Tomasz Bujok'
   */
-class MethodCountRuleTest extends AbstractRuleTestCase {
+class MethodCountRuleTest extends GenericAbstractRuleTestCase<MethodCountRule> {
 
     @Test
     void testRuleProperties() {
@@ -69,7 +68,7 @@ class MethodCountRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected MethodCountRule createRule() {
         new MethodCountRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/size/MethodSizeRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/size/MethodSizeRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.size
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class MethodSizeRuleTest extends AbstractRuleTestCase {
+class MethodSizeRuleTest extends GenericAbstractRuleTestCase<MethodSizeRule> {
 
     @Test
     void testRuleProperties() {
@@ -158,7 +157,7 @@ class MethodSizeRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected MethodSizeRule createRule() {
         new MethodSizeRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/size/NestedBlockDepthRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/size/NestedBlockDepthRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.size
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class NestedBlockDepthRuleTest extends AbstractRuleTestCase {
+class NestedBlockDepthRuleTest extends GenericAbstractRuleTestCase<NestedBlockDepthRule> {
 
     @Test
     void testRuleProperties() {
@@ -373,7 +372,7 @@ class NestedBlockDepthRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected NestedBlockDepthRule createRule() {
         new NestedBlockDepthRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/size/ParameterCountRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/size/ParameterCountRuleTest.groovy
@@ -15,18 +15,17 @@
  */
 package org.codenarc.rule.size
 
-import org.codenarc.rule.Rule
-import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
-
 import static org.codenarc.test.TestUtil.shouldFail
+
+import org.codenarc.rule.GenericAbstractRuleTestCase
+import org.junit.Test
 
 /**
  * Tests for ParameterCountRule
  *
  * @author Maciej Ziarko
  */
-class ParameterCountRuleTest extends AbstractRuleTestCase {
+class ParameterCountRuleTest extends GenericAbstractRuleTestCase<ParameterCountRule> {
 
     @Test
     void testRuleProperties() {
@@ -254,7 +253,7 @@ class ParameterCountRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ParameterCountRule createRule() {
         new ParameterCountRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/AddEmptyStringRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/AddEmptyStringRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class AddEmptyStringRuleTest extends AbstractRuleTestCase {
+class AddEmptyStringRuleTest extends GenericAbstractRuleTestCase<AddEmptyStringRule> {
 
     private static final VIOLATION_MESSAGE = 'Concatenating an empty string is an inefficient way to convert an object to a String. Consider using toString() or String.valueOf(Object)'
 
@@ -72,7 +71,7 @@ class AddEmptyStringRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected AddEmptyStringRule createRule() {
         new AddEmptyStringRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/ConsecutiveLiteralAppendsRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/ConsecutiveLiteralAppendsRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ConsecutiveLiteralAppendsRuleTest extends AbstractRuleTestCase {
+class ConsecutiveLiteralAppendsRuleTest extends GenericAbstractRuleTestCase<ConsecutiveLiteralAppendsRule> {
 
     @Test
     void testRuleProperties() {
@@ -72,7 +71,7 @@ class ConsecutiveLiteralAppendsRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ConsecutiveLiteralAppendsRule createRule() {
         new ConsecutiveLiteralAppendsRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/ConsecutiveStringConcatenationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/ConsecutiveStringConcatenationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class ConsecutiveStringConcatenationRuleTest extends AbstractRuleTestCase {
+class ConsecutiveStringConcatenationRuleTest extends GenericAbstractRuleTestCase<ConsecutiveStringConcatenationRule> {
 
     @Test
     void testRuleProperties() {
@@ -101,7 +100,7 @@ class ConsecutiveStringConcatenationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ConsecutiveStringConcatenationRule createRule() {
         new ConsecutiveStringConcatenationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryBigDecimalInstantiationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryBigDecimalInstantiationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryBigDecimalInstantiationRuleTest extends AbstractRuleTestCase {
+class UnnecessaryBigDecimalInstantiationRuleTest extends GenericAbstractRuleTestCase<UnnecessaryBigDecimalInstantiationRule> {
 
     @Test
     void testRuleProperties() {
@@ -94,7 +93,7 @@ class UnnecessaryBigDecimalInstantiationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryBigDecimalInstantiationRule createRule() {
         new UnnecessaryBigDecimalInstantiationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryBigIntegerInstantiationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryBigIntegerInstantiationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryBigIntegerInstantiationRuleTest extends AbstractRuleTestCase {
+class UnnecessaryBigIntegerInstantiationRuleTest extends GenericAbstractRuleTestCase<UnnecessaryBigIntegerInstantiationRule> {
 
     @Test
     void testRuleProperties() {
@@ -51,7 +50,7 @@ class UnnecessaryBigIntegerInstantiationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryBigIntegerInstantiationRule createRule() {
         new UnnecessaryBigIntegerInstantiationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryBooleanExpressionRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryBooleanExpressionRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class UnnecessaryBooleanExpressionRuleTest extends AbstractRuleTestCase {
+class UnnecessaryBooleanExpressionRuleTest extends GenericAbstractRuleTestCase<UnnecessaryBooleanExpressionRule> {
 
     @Test
     void testRuleProperties() {
@@ -195,7 +194,7 @@ class UnnecessaryBooleanExpressionRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryBooleanExpressionRule createRule() {
         new UnnecessaryBooleanExpressionRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryBooleanInstantiationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryBooleanInstantiationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class UnnecessaryBooleanInstantiationRuleTest extends AbstractRuleTestCase {
+class UnnecessaryBooleanInstantiationRuleTest extends GenericAbstractRuleTestCase<UnnecessaryBooleanInstantiationRule> {
 
     @Test
     void testRuleProperties() {
@@ -97,7 +96,7 @@ class UnnecessaryBooleanInstantiationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryBooleanInstantiationRule createRule() {
         new UnnecessaryBooleanInstantiationRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryCallForLastElementRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryCallForLastElementRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryCallForLastElementRuleTest extends AbstractRuleTestCase {
+class UnnecessaryCallForLastElementRuleTest extends GenericAbstractRuleTestCase<UnnecessaryCallForLastElementRule> {
 
     @Test
     void testRuleProperties() {
@@ -96,7 +95,7 @@ class UnnecessaryCallForLastElementRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryCallForLastElementRule createRule() {
         new UnnecessaryCallForLastElementRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryCallToSubstringRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryCallToSubstringRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryCallToSubstringRuleTest extends AbstractRuleTestCase {
+class UnnecessaryCallToSubstringRuleTest extends GenericAbstractRuleTestCase<UnnecessaryCallToSubstringRule> {
 
     @Test
     void testRuleProperties() {
@@ -50,7 +49,7 @@ class UnnecessaryCallToSubstringRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryCallToSubstringRule createRule() {
         new UnnecessaryCallToSubstringRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryCastRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryCastRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for UnnecessaryCastRule
  *
  * @author Chris Mair
  */
-class UnnecessaryCastRuleTest extends AbstractRuleTestCase {
+class UnnecessaryCastRuleTest extends GenericAbstractRuleTestCase<UnnecessaryCastRule> {
 
     @Test
     void testRuleProperties() {
@@ -65,7 +64,7 @@ class UnnecessaryCastRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryCastRule createRule() {
         new UnnecessaryCastRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryCatchBlockRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryCatchBlockRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryCatchBlockRuleTest extends AbstractRuleTestCase {
+class UnnecessaryCatchBlockRuleTest extends GenericAbstractRuleTestCase<UnnecessaryCatchBlockRule> {
 
     @Test
     void testRuleProperties() {
@@ -80,7 +79,7 @@ class UnnecessaryCatchBlockRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryCatchBlockRule createRule() {
         new UnnecessaryCatchBlockRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryCollectCallRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryCollectCallRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryCollectCallRuleTest extends AbstractRuleTestCase {
+class UnnecessaryCollectCallRuleTest extends GenericAbstractRuleTestCase<UnnecessaryCollectCallRule> {
 
     @Test
     void testRuleProperties() {
@@ -95,7 +94,7 @@ class UnnecessaryCollectCallRuleTest extends AbstractRuleTestCase {
         assertSingleViolation(SOURCE, 2, '["1", "2", "3"].collect', 'The call to collect could probably be rewritten as a spread expression: [1, 2, 3]*.bytes')
     }
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryCollectCallRule createRule() {
         new UnnecessaryCollectCallRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryCollectionCallRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryCollectionCallRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryCollectionCallRuleTest extends AbstractRuleTestCase {
+class UnnecessaryCollectionCallRuleTest extends GenericAbstractRuleTestCase<UnnecessaryCollectionCallRule> {
 
     @Test
     void testRuleProperties() {
@@ -77,7 +76,7 @@ class UnnecessaryCollectionCallRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryCollectionCallRule createRule() {
         new UnnecessaryCollectionCallRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryConstructorRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryConstructorRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author 'Tomasz Bujok'
  * @author Chris Mair
   */
-class UnnecessaryConstructorRuleTest extends AbstractRuleTestCase {
+class UnnecessaryConstructorRuleTest extends GenericAbstractRuleTestCase<UnnecessaryConstructorRule> {
 
     @Test
     void testRuleProperties() {
@@ -170,7 +169,7 @@ class UnnecessaryConstructorRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryConstructorRule createRule() {
         new UnnecessaryConstructorRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryDefInFieldDeclarationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryDefInFieldDeclarationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class UnnecessaryDefInFieldDeclarationRuleTest extends AbstractRuleTestCase {
+class UnnecessaryDefInFieldDeclarationRuleTest extends GenericAbstractRuleTestCase<UnnecessaryDefInFieldDeclarationRule> {
 
     @Test
     void testRuleProperties() {
@@ -215,7 +214,7 @@ class UnnecessaryDefInFieldDeclarationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryDefInFieldDeclarationRule createRule() {
         new UnnecessaryDefInFieldDeclarationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryDefInMethodDeclarationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryDefInMethodDeclarationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryDefInMethodDeclarationRuleTest extends AbstractRuleTestCase {
+class UnnecessaryDefInMethodDeclarationRuleTest extends GenericAbstractRuleTestCase<UnnecessaryDefInMethodDeclarationRule> {
 
     @Test
     void testRuleProperties() {
@@ -238,7 +237,7 @@ class UnnecessaryDefInMethodDeclarationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryDefInMethodDeclarationRule createRule() {
         new UnnecessaryDefInMethodDeclarationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryDefInVariableDeclarationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryDefInVariableDeclarationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author René Scheibe
   */
-class UnnecessaryDefInVariableDeclarationRuleTest extends AbstractRuleTestCase {
+class UnnecessaryDefInVariableDeclarationRuleTest extends GenericAbstractRuleTestCase<UnnecessaryDefInVariableDeclarationRule> {
 
     @Test
     void testRuleProperties() {
@@ -226,7 +225,7 @@ class UnnecessaryDefInVariableDeclarationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryDefInVariableDeclarationRule createRule() {
         new UnnecessaryDefInVariableDeclarationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryDotClassRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryDotClassRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Dean Del Ponte
   */
-class UnnecessaryDotClassRuleTest extends AbstractRuleTestCase {
+class UnnecessaryDotClassRuleTest extends GenericAbstractRuleTestCase<UnnecessaryDotClassRule> {
 
     @Test
     void testRuleProperties() {
@@ -66,7 +65,7 @@ class UnnecessaryDotClassRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryDotClassRule createRule() {
         new UnnecessaryDotClassRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryDoubleInstantiationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryDoubleInstantiationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryDoubleInstantiationRuleTest extends AbstractRuleTestCase {
+class UnnecessaryDoubleInstantiationRuleTest extends GenericAbstractRuleTestCase<UnnecessaryDoubleInstantiationRule> {
 
     @Test
     void testRuleProperties() {
@@ -59,7 +58,7 @@ class UnnecessaryDoubleInstantiationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryDoubleInstantiationRule createRule() {
         new UnnecessaryDoubleInstantiationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryElseStatementRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryElseStatementRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Victor Savkin
   */
-class UnnecessaryElseStatementRuleTest extends AbstractRuleTestCase {
+class UnnecessaryElseStatementRuleTest extends GenericAbstractRuleTestCase<UnnecessaryElseStatementRule> {
 
     @Test
     void testRuleProperties() {
@@ -224,7 +223,7 @@ class UnnecessaryElseStatementRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryElseStatementRule createRule() {
         new UnnecessaryElseStatementRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryFinalOnPrivateMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryFinalOnPrivateMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryFinalOnPrivateMethodRuleTest extends AbstractRuleTestCase {
+class UnnecessaryFinalOnPrivateMethodRuleTest extends GenericAbstractRuleTestCase<UnnecessaryFinalOnPrivateMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -51,7 +50,7 @@ class UnnecessaryFinalOnPrivateMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryFinalOnPrivateMethodRule createRule() {
         new UnnecessaryFinalOnPrivateMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryFloatInstantiationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryFloatInstantiationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryFloatInstantiationRuleTest extends AbstractRuleTestCase {
+class UnnecessaryFloatInstantiationRuleTest extends GenericAbstractRuleTestCase<UnnecessaryFloatInstantiationRule> {
 
     @Test
     void testRuleProperties() {
@@ -67,7 +66,7 @@ class UnnecessaryFloatInstantiationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryFloatInstantiationRule createRule() {
         new UnnecessaryFloatInstantiationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryGStringRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryGStringRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author 'Hamlet D'Arcy'
   */
-class UnnecessaryGStringRuleTest extends AbstractRuleTestCase {
+class UnnecessaryGStringRuleTest extends GenericAbstractRuleTestCase<UnnecessaryGStringRule> {
 
     @Test
     void testRuleProperties() {
@@ -124,7 +123,7 @@ I am a string
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryGStringRule createRule() {
         new UnnecessaryGStringRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryGetterRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryGetterRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryGetterRuleTest extends AbstractRuleTestCase {
+class UnnecessaryGetterRuleTest extends GenericAbstractRuleTestCase<UnnecessaryGetterRule> {
 
     @Test
     void testRuleProperties() {
@@ -119,7 +118,7 @@ class UnnecessaryGetterRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryGetterRule createRule() {
         new UnnecessaryGetterRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryIfStatementRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryIfStatementRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class UnnecessaryIfStatementRuleTest extends AbstractRuleTestCase {
+class UnnecessaryIfStatementRuleTest extends GenericAbstractRuleTestCase<UnnecessaryIfStatementRule> {
 
     @Test
     void testRuleProperties() {
@@ -238,7 +237,7 @@ class UnnecessaryIfStatementRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryIfStatementRule createRule() {
         new UnnecessaryIfStatementRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryInstanceOfCheckRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryInstanceOfCheckRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryInstanceOfCheckRuleTest extends AbstractRuleTestCase {
+class UnnecessaryInstanceOfCheckRuleTest extends GenericAbstractRuleTestCase<UnnecessaryInstanceOfCheckRule> {
 
     @Test
     void testRuleProperties() {
@@ -75,7 +74,7 @@ class UnnecessaryInstanceOfCheckRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryInstanceOfCheckRule createRule() {
         new UnnecessaryInstanceOfCheckRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryInstantiationToGetClassRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryInstantiationToGetClassRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryInstantiationToGetClassRuleTest extends AbstractRuleTestCase {
+class UnnecessaryInstantiationToGetClassRuleTest extends GenericAbstractRuleTestCase<UnnecessaryInstantiationToGetClassRule> {
 
     @Test
     void testRuleProperties() {
@@ -63,7 +62,7 @@ class UnnecessaryInstantiationToGetClassRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryInstantiationToGetClassRule createRule() {
         new UnnecessaryInstantiationToGetClassRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryIntegerInstantiationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryIntegerInstantiationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryIntegerInstantiationRuleTest extends AbstractRuleTestCase {
+class UnnecessaryIntegerInstantiationRuleTest extends GenericAbstractRuleTestCase<UnnecessaryIntegerInstantiationRule> {
 
     @Test
     void testRuleProperties() {
@@ -59,7 +58,7 @@ class UnnecessaryIntegerInstantiationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryIntegerInstantiationRule createRule() {
         new UnnecessaryIntegerInstantiationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryLongInstantiationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryLongInstantiationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryLongInstantiationRuleTest extends AbstractRuleTestCase {
+class UnnecessaryLongInstantiationRuleTest extends GenericAbstractRuleTestCase<UnnecessaryLongInstantiationRule> {
 
     @Test
     void testRuleProperties() {
@@ -59,7 +58,7 @@ class UnnecessaryLongInstantiationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryLongInstantiationRule createRule() {
         new UnnecessaryLongInstantiationRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryModOneRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryModOneRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryModOneRuleTest extends AbstractRuleTestCase {
+class UnnecessaryModOneRuleTest extends GenericAbstractRuleTestCase<UnnecessaryModOneRule> {
 
     @Test
     void testRuleProperties() {
@@ -53,7 +52,7 @@ class UnnecessaryModOneRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryModOneRule createRule() {
         new UnnecessaryModOneRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryNullCheckBeforeInstanceOfRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryNullCheckBeforeInstanceOfRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author 'Hamlet D'Arcy'
  * @author Chris Mair
  */
-class UnnecessaryNullCheckBeforeInstanceOfRuleTest extends AbstractRuleTestCase {
+class UnnecessaryNullCheckBeforeInstanceOfRuleTest extends GenericAbstractRuleTestCase<UnnecessaryNullCheckBeforeInstanceOfRule> {
 
     @Test
     void testRuleProperties() {
@@ -97,7 +96,7 @@ class UnnecessaryNullCheckBeforeInstanceOfRuleTest extends AbstractRuleTestCase 
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryNullCheckBeforeInstanceOfRule createRule() {
         new UnnecessaryNullCheckBeforeInstanceOfRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryNullCheckRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryNullCheckRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
  */
-class UnnecessaryNullCheckRuleTest extends AbstractRuleTestCase {
+class UnnecessaryNullCheckRuleTest extends GenericAbstractRuleTestCase<UnnecessaryNullCheckRule> {
 
     @Test
     void testRuleProperties() {
@@ -161,7 +160,7 @@ class UnnecessaryNullCheckRuleTest extends AbstractRuleTestCase {
 //    }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryNullCheckRule createRule() {
         new UnnecessaryNullCheckRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryObjectReferencesRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryObjectReferencesRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryObjectReferencesRuleTest extends AbstractRuleTestCase {
+class UnnecessaryObjectReferencesRuleTest extends GenericAbstractRuleTestCase<UnnecessaryObjectReferencesRule> {
 
     @Test
     void testRuleProperties() {
@@ -198,7 +197,7 @@ class UnnecessaryObjectReferencesRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryObjectReferencesRule createRule() {
         new UnnecessaryObjectReferencesRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryOverridingMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryOverridingMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author 'Sven Lange'
   */
-class UnnecessaryOverridingMethodRuleTest extends AbstractRuleTestCase {
+class UnnecessaryOverridingMethodRuleTest extends GenericAbstractRuleTestCase<UnnecessaryOverridingMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -84,7 +83,7 @@ class UnnecessaryOverridingMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryOverridingMethodRule createRule() {
         new UnnecessaryOverridingMethodRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryPackageReferenceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryPackageReferenceRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.codenarc.util.GroovyVersion
 import org.junit.Test
 
@@ -25,7 +24,7 @@ import org.junit.Test
  *
  * @author Chris Mair
  */
-class UnnecessaryPackageReferenceRuleTest extends AbstractRuleTestCase {
+class UnnecessaryPackageReferenceRuleTest extends GenericAbstractRuleTestCase<UnnecessaryPackageReferenceRule> {
 
     @Test
     void testRuleProperties() {
@@ -293,7 +292,7 @@ class UnnecessaryPackageReferenceRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryPackageReferenceRule createRule() {
         new UnnecessaryPackageReferenceRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryParenthesesForMethodCallWithClosureRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryParenthesesForMethodCallWithClosureRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Marcin Erdmann
   */
-class UnnecessaryParenthesesForMethodCallWithClosureRuleTest extends AbstractRuleTestCase {
+class UnnecessaryParenthesesForMethodCallWithClosureRuleTest extends GenericAbstractRuleTestCase<UnnecessaryParenthesesForMethodCallWithClosureRule> {
 
     @Test
     void testRuleProperties() {
@@ -103,7 +102,7 @@ class UnnecessaryParenthesesForMethodCallWithClosureRuleTest extends AbstractRul
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryParenthesesForMethodCallWithClosureRule createRule() {
         new UnnecessaryParenthesesForMethodCallWithClosureRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryPublicModifierRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryPublicModifierRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryPublicModifierRuleTest extends AbstractRuleTestCase {
+class UnnecessaryPublicModifierRuleTest extends GenericAbstractRuleTestCase<UnnecessaryPublicModifierRule> {
 
     @Test
     void testRuleProperties() {
@@ -157,7 +156,7 @@ class UnnecessaryPublicModifierRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryPublicModifierRule createRule() {
         new UnnecessaryPublicModifierRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryReturnKeywordRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryReturnKeywordRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryReturnKeywordRuleTest extends AbstractRuleTestCase {
+class UnnecessaryReturnKeywordRuleTest extends GenericAbstractRuleTestCase<UnnecessaryReturnKeywordRule> {
 
     @Test
     void testRuleProperties() {
@@ -79,7 +78,7 @@ class UnnecessaryReturnKeywordRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryReturnKeywordRule createRule() {
         new UnnecessaryReturnKeywordRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessarySafeNavigationOperatorRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessarySafeNavigationOperatorRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for UnnecessarySafeNavigationOperatorRule
  *
  * @author Chris Mair
  */
-class UnnecessarySafeNavigationOperatorRuleTest extends AbstractRuleTestCase {
+class UnnecessarySafeNavigationOperatorRuleTest extends GenericAbstractRuleTestCase<UnnecessarySafeNavigationOperatorRule> {
 
     @Test
     void testRuleProperties() {
@@ -123,7 +122,7 @@ class UnnecessarySafeNavigationOperatorRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessarySafeNavigationOperatorRule createRule() {
         new UnnecessarySafeNavigationOperatorRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessarySelfAssignmentRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessarySelfAssignmentRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessarySelfAssignmentRuleTest extends AbstractRuleTestCase {
+class UnnecessarySelfAssignmentRuleTest extends GenericAbstractRuleTestCase<UnnecessarySelfAssignmentRule> {
 
     @Test
     void testRuleProperties() {
@@ -78,7 +77,7 @@ class UnnecessarySelfAssignmentRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessarySelfAssignmentRule createRule() {
         new UnnecessarySelfAssignmentRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessarySemicolonRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessarySemicolonRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessarySemicolonRuleTest extends AbstractRuleTestCase {
+class UnnecessarySemicolonRuleTest extends GenericAbstractRuleTestCase<UnnecessarySemicolonRule> {
 
     @Test
     void testRuleProperties() {
@@ -174,7 +173,7 @@ class UnnecessarySemicolonRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessarySemicolonRule createRule() {
         new UnnecessarySemicolonRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessarySetterRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessarySetterRuleTest.groovy
@@ -15,14 +15,13 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for UnnecessarySetterRule
  */
-class UnnecessarySetterRuleTest extends AbstractRuleTestCase {
+class UnnecessarySetterRuleTest extends GenericAbstractRuleTestCase<UnnecessarySetterRule> {
 
     @Test
     void testRuleProperties() {
@@ -70,7 +69,7 @@ class UnnecessarySetterRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessarySetterRule createRule() {
         new UnnecessarySetterRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryStringInstantiationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryStringInstantiationRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class UnnecessaryStringInstantiationRuleTest extends AbstractRuleTestCase {
+class UnnecessaryStringInstantiationRuleTest extends GenericAbstractRuleTestCase<UnnecessaryStringInstantiationRule> {
 
     @Test
     void testRuleProperties() {
@@ -86,7 +85,7 @@ class UnnecessaryStringInstantiationRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryStringInstantiationRule createRule() {
         new UnnecessaryStringInstantiationRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessarySubstringRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessarySubstringRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessarySubstringRuleTest extends AbstractRuleTestCase {
+class UnnecessarySubstringRuleTest extends GenericAbstractRuleTestCase<UnnecessarySubstringRule> {
 
     @Test
     void testRuleProperties() {
@@ -63,7 +62,7 @@ class UnnecessarySubstringRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessarySubstringRule createRule() {
         new UnnecessarySubstringRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryTernaryExpressionRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryTernaryExpressionRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class UnnecessaryTernaryExpressionRuleTest extends AbstractRuleTestCase {
+class UnnecessaryTernaryExpressionRuleTest extends GenericAbstractRuleTestCase<UnnecessaryTernaryExpressionRule> {
 
     @Test
     void testRuleProperties() {
@@ -191,7 +190,7 @@ class UnnecessaryTernaryExpressionRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryTernaryExpressionRule createRule() {
         new UnnecessaryTernaryExpressionRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryToStringRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryToStringRuleTest.groovy
@@ -15,16 +15,15 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
 
 /**
  * Tests for UnnecessaryToStringRule
  *
  * @author Chris Mair
  */
-class UnnecessaryToStringRuleTest extends AbstractRuleTestCase {
+class UnnecessaryToStringRuleTest extends GenericAbstractRuleTestCase<UnnecessaryToStringRule> {
 
     @Test
     void testRuleProperties() {
@@ -108,7 +107,7 @@ class UnnecessaryToStringRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryToStringRule createRule() {
         new UnnecessaryToStringRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryTransientModifierRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unnecessary/UnnecessaryTransientModifierRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unnecessary
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Hamlet D'Arcy
   */
-class UnnecessaryTransientModifierRuleTest extends AbstractRuleTestCase {
+class UnnecessaryTransientModifierRuleTest extends GenericAbstractRuleTestCase<UnnecessaryTransientModifierRule> {
 
     @Test
     void testRuleProperties() {
@@ -77,7 +76,7 @@ class UnnecessaryTransientModifierRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnnecessaryTransientModifierRule createRule() {
         new UnnecessaryTransientModifierRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unused/UnusedArrayRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unused/UnusedArrayRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unused
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Your Name Here
   */
-class UnusedArrayRuleTest extends AbstractRuleTestCase {
+class UnusedArrayRuleTest extends GenericAbstractRuleTestCase<UnusedArrayRule> {
 
     @Test
     void testRuleProperties() {
@@ -80,7 +79,7 @@ class UnusedArrayRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnusedArrayRule createRule() {
         new UnusedArrayRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/unused/UnusedMethodParameterRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unused/UnusedMethodParameterRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unused
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -25,7 +24,7 @@ import org.junit.Test
  * @author Hamlet D'Arcy
  * @author Chris Mair
  */
-class UnusedMethodParameterRuleTest extends AbstractRuleTestCase {
+class UnusedMethodParameterRuleTest extends GenericAbstractRuleTestCase<UnusedMethodParameterRule> {
 
     @Test
     void testRuleProperties() {
@@ -240,7 +239,7 @@ class UnusedMethodParameterRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnusedMethodParameterRule createRule() {
         new UnusedMethodParameterRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unused/UnusedObjectRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unused/UnusedObjectRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unused
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Your Name Here
  */
-class UnusedObjectRuleTest extends AbstractRuleTestCase {
+class UnusedObjectRuleTest extends GenericAbstractRuleTestCase<UnusedObjectRule> {
 
     @Test
     void testRuleProperties() {
@@ -118,7 +117,7 @@ class UnusedObjectRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnusedObjectRule createRule() {
         new UnusedObjectRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/unused/UnusedPrivateFieldRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unused/UnusedPrivateFieldRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unused
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -26,7 +25,7 @@ import org.junit.Test
  * @author Hamlet D'Arcy
  *
   */
-class UnusedPrivateFieldRuleTest extends AbstractRuleTestCase {
+class UnusedPrivateFieldRuleTest extends GenericAbstractRuleTestCase<UnusedPrivateFieldRule> {
 
     @Test
     void testRuleProperties() {
@@ -461,7 +460,7 @@ class UnusedPrivateFieldRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnusedPrivateFieldRule createRule() {
         new UnusedPrivateFieldRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/unused/UnusedPrivateMethodParameterRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unused/UnusedPrivateMethodParameterRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unused
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class UnusedPrivateMethodParameterRuleTest extends AbstractRuleTestCase {
+class UnusedPrivateMethodParameterRuleTest extends GenericAbstractRuleTestCase<UnusedPrivateMethodParameterRule> {
 
     @Test
     void testRuleProperties() {
@@ -174,7 +173,7 @@ class UnusedPrivateMethodParameterRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnusedPrivateMethodParameterRule createRule() {
         new UnusedPrivateMethodParameterRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/unused/UnusedPrivateMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unused/UnusedPrivateMethodRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unused
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class UnusedPrivateMethodRuleTest extends AbstractRuleTestCase {
+class UnusedPrivateMethodRuleTest extends GenericAbstractRuleTestCase<UnusedPrivateMethodRule> {
 
     @Test
     void testRuleProperties() {
@@ -523,7 +522,7 @@ class UnusedPrivateMethodRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnusedPrivateMethodRule createRule() {
         new UnusedPrivateMethodRule()
     }
 

--- a/src/test/groovy/org/codenarc/rule/unused/UnusedVariableRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/unused/UnusedVariableRuleTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.codenarc.rule.unused
 
-import org.codenarc.rule.AbstractRuleTestCase
-import org.codenarc.rule.Rule
+import org.codenarc.rule.GenericAbstractRuleTestCase
 import org.junit.Test
 
 /**
@@ -24,7 +23,7 @@ import org.junit.Test
  *
  * @author Chris Mair
   */
-class UnusedVariableRuleTest extends AbstractRuleTestCase {
+class UnusedVariableRuleTest extends GenericAbstractRuleTestCase<UnusedVariableRule> {
 
     @Test
     void testRuleProperties() {
@@ -480,7 +479,7 @@ class UnusedVariableRuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected UnusedVariableRule createRule() {
         new UnusedVariableRule()
     }
 

--- a/templates/Test.groovy
+++ b/templates/Test.groovy
@@ -17,14 +17,14 @@ package org.codenarc.rule.${ruleCategory}
 
 import org.codenarc.rule.Rule
 import org.junit.Test
-import org.codenarc.rule.AbstractRuleTestCase
+import org.codenarc.rule.GenericAbstractRuleTestCase
 
 /**
  * Tests for ${ruleName}Rule
  *
  * @author ${authorName}
  */
-class ${ruleName}RuleTest extends AbstractRuleTestCase {
+class ${ruleName}RuleTest extends GenericAbstractRuleTestCase<${ruleName}Rule> {
 
     @Test
     void testRuleProperties() {
@@ -59,7 +59,7 @@ class ${ruleName}RuleTest extends AbstractRuleTestCase {
     }
 
     @Override
-    protected Rule createRule() {
+    protected ${ruleName}Rule createRule() {
         new ${ruleName}Rule()
     }
 }


### PR DESCRIPTION
Part of #280.

I refrained from collapsing `GenericAbstractRuleTestCase` into `AbstractRuleTestCase` because it's a breaking change for anyone using `AbstractRuleTestCase` to test their custom rules. I'll leave the decision to you but if you want to go ahead then you can do it by:
- deleting `AbstractRuleTestCase`
- renaming `GenericAbstractRuleTestCase` to `AbstractRuleTestCase`
- updating `templates/Test.groovy`