### PR TITLE
Add equivalent linux command line example

### DIFF
--- a/src/site/apt/codenarc-command-line.apt
+++ b/src/site/apt/codenarc-command-line.apt
@@ -84,3 +84,10 @@ CodeNarc - Run From Command-Line
 @java -classpath %GROOVY_JAR%;lib/CodeNarc-0.5.jar;lib/slf4j-api-1.7.25.jar;lib org.codenarc.CodeNarc %*
 +----------------------------------------------------------------------------------------
 
+  Here is the equivalent Linux command.
+
++----------------------------------------------------------------------------------------
+export GROOVY_JAR="$GROOVY_HOME/embeddable/groovy-all-1.5.6.jar"
+
+java -classpath $GROOVY_JAR:lib/CodeNarc-0.5.jar:lib/slf4j-api-1.7.25.jar:lib org.codenarc.CodeNarc $*
++----------------------------------------------------------------------------------------


### PR DESCRIPTION
It took me a little fiddling to work out the equivalent command, so I think it would be helpful to see the linux command needed.

I didn't actually need the `:lib` bit:

```
$ java -cp slf4j-api-1.7.25.jar:groovy-all-2.4.13-indy.jar:CodeNarc-1.1.jar org.codenarc.CodeNarc -help
CodeNarc - static analysis for Groovy',
Usage: java org.codenarc.CodeNarc [OPTIONS]
  where OPTIONS are zero or more command-line options of the form "-NAME[=VALUE]":
    -basedir=<DIR>
        The base (root) directory for the source code to be analyzed.
        Defaults to the current directory (".").
    -includes=<PATTERNS>
        The comma-separated list of Ant-style file patterns specifying files that must
        be included. Defaults to "**/*.groovy".
    -excludes=<PATTERNS>
        The comma-separated list of Ant-style file patterns specifying files that must
        be excluded. No files are excluded when omitted.
    -rulesetfiles=<FILENAMES>
        The path to the Groovy or XML RuleSet definition files, relative to the classpath.
        This can be a single file path, or multiple paths separated by commas.
        Defaults to "rulesets/basic.xml"
    -title=<REPORT TITLE>
        The title for this analysis; used in the output report(s), if supported by the report type. Optional.
    -report=<REPORT-TYPE[:FILENAME]>
        The definition of the report to produce. The option value is of the form
        TYPE[:FILENAME], where TYPE is "html", "text", "xml", or "console" and FILENAME is the filename (with
        optional path) of the output report filename. If the report filename is
        omitted, the default filename is used for the specified report type
        ("CodeNarcReport.html" for "html" and "CodeNarcXmlReport.xml" for "xml"). If no
        report option is specified, default to a single "html" report with the
        default filename.
    -help
        Display the command-line help. If present, this must be the only command-line parameter.
  Example command-line invocations:
    java org.codenarc.CodeNarc
    java org.codenarc.CodeNarc -rulesetfiles="rulesets/basic.xml" title="My Project"
    java org.codenarc.CodeNarc -report=xml:MyXmlReport.xml -report=html
    java org.codenarc.CodeNarc -help'
```

but I thought I'd leave the two commands as equivalent.