### PR TITLE
Fix Indentation Rule to work with spock block labels

### DIFF
--- a/src/test/groovy/org/codenarc/rule/formatting/IndentationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/IndentationRuleTest.groovy
@@ -686,6 +686,28 @@ class IndentationRuleTest extends AbstractRuleTestCase<IndentationRule> {
         assertNoViolations(SOURCE)
     }
 
+    @Test
+    void test_SpockTestWithLabels_NoViolation() {
+        final SOURCE = '''
+            |class MySpec extends Specification {
+            |    void 'some feature'() {
+            |        given: 'something'
+            |        def a = new Object()
+            |
+            |        when: 'something is done'
+            |        def b = a.toString()
+            |
+            |        then: 'something happens'
+            |        b != ''
+            |
+            |        and:
+            |        b != 'raccoon'
+            |    }
+            |}
+        '''.stripMargin()
+        assertNoViolations(SOURCE)
+    }
+
     @Override
     protected IndentationRule createRule() {
         new IndentationRule()


### PR DESCRIPTION
I know there has been discussion on here before that spock can make detecting issues more complicated. I think the logic in `isSpockBlock()` should give good enough coverage. Also, since it is a skip, it will not falsely mark any lines as violations.

This fixes #308