### PR TITLE
Allow newline after elvis operator

### DIFF
--- a/src/main/groovy/org/codenarc/rule/formatting/SpaceAroundOperatorRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/SpaceAroundOperatorRule.groovy
@@ -109,12 +109,18 @@ class SpaceAroundOperatorAstVisitor extends AbstractAstVisitor {
     }
 
     private void processElvisExpression(ElvisOperatorExpression expression) {
-        def line = sourceCode.lines[expression.lineNumber - 1]
-        if (line.contains('?:')) {
-            if (!(line =~ /\s\?\:/)) {
+        String line = sourceCode.lines[expression.lineNumber - 1]
+
+        /* for assert statements expression.columnNumber is not where the elvis operator "?:" starts, but where the
+         * assertion starts. To handle this problem, look for the first instance of "?:" starting from the columnNumber
+         */
+        int index = line.indexOf('?:', expression.columnNumber - 1)
+
+        if (index >= 0) {
+            if (index > 0 && line.subSequence(index - 1, index + 2) =~ /\S\?\:/) {
                 addViolation(expression, "The operator \"?:\" within class $currentClassName is not preceded by a space or whitespace")
             }
-            if (line =~ /\?\:(\S)/) {
+            if (index + 3 < line.size() && line.subSequence(index, index + 3) =~ /\?\:(\S)/) {
                 addViolation(expression, "The operator \"?:\" within class $currentClassName is not followed by a space or whitespace")
             }
         }

--- a/src/main/groovy/org/codenarc/rule/formatting/SpaceAroundOperatorRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/SpaceAroundOperatorRule.groovy
@@ -16,16 +16,16 @@
 package org.codenarc.rule.formatting
 
 import org.codehaus.groovy.ast.expr.BinaryExpression
+import org.codehaus.groovy.ast.expr.BooleanExpression
 import org.codehaus.groovy.ast.expr.CastExpression
-import org.codehaus.groovy.ast.expr.Expression
-import org.codenarc.rule.AbstractAstVisitor
-import org.codenarc.rule.AbstractAstVisitorRule
-import org.codehaus.groovy.ast.expr.TernaryExpression
+import org.codehaus.groovy.ast.expr.DeclarationExpression
 import org.codehaus.groovy.ast.expr.ElvisOperatorExpression
+import org.codehaus.groovy.ast.expr.Expression
 import org.codehaus.groovy.ast.expr.MethodCallExpression
 import org.codehaus.groovy.ast.expr.PropertyExpression
-import org.codehaus.groovy.ast.expr.DeclarationExpression
-import org.codehaus.groovy.ast.expr.BooleanExpression
+import org.codehaus.groovy.ast.expr.TernaryExpression
+import org.codenarc.rule.AbstractAstVisitor
+import org.codenarc.rule.AbstractAstVisitorRule
 
 /**
  * Check that there is at least one space (blank) or whitespace around each binary operator,
@@ -40,7 +40,7 @@ import org.codehaus.groovy.ast.expr.BooleanExpression
  * Known limitation: Does not catch violations of certain ternary expressions.
  *
  * @author Chris Mair
-  */
+ */
 class SpaceAroundOperatorRule extends AbstractAstVisitorRule {
 
     String name = 'SpaceAroundOperator'
@@ -64,8 +64,7 @@ class SpaceAroundOperatorAstVisitor extends AbstractAstVisitor {
         if (isFirstVisit(expression)) {
             if (expression instanceof ElvisOperatorExpression) {
                 processElvisExpression(expression)
-            }
-            else {
+            } else {
                 processTernaryExpression(expression)
             }
         }
@@ -115,7 +114,7 @@ class SpaceAroundOperatorAstVisitor extends AbstractAstVisitor {
             if (!(line =~ /\s\?\:/)) {
                 addViolation(expression, "The operator \"?:\" within class $currentClassName is not preceded by a space or whitespace")
             }
-            if (!(line =~ /\?\:\s/)) {
+            if (line =~ /\?\:(\S)/) {
                 addViolation(expression, "The operator \"?:\" within class $currentClassName is not followed by a space or whitespace")
             }
         }
@@ -170,7 +169,7 @@ class SpaceAroundOperatorAstVisitor extends AbstractAstVisitor {
     }
 
     private int rightMostColumn(Expression expression) {
-        switch(expression) {
+        switch (expression) {
             case BinaryExpression:
                 return rightMostColumn(expression.rightExpression)
             case MethodCallExpression:

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceAroundOperatorRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceAroundOperatorRuleTest.groovy
@@ -212,12 +212,11 @@ class SpaceAroundOperatorRuleTest extends AbstractRuleTestCase<SpaceAroundOperat
                     def greeting = fullname?:'you'
                     def f = funds.collect {it.fundSortOrder}?:[]
                     assert model.UserID == expectedModel.UserID?:null
-                    def doubleElvis = fullname ?:lastname ?: 'me'
+                    def tripleElvis = fullname ?:lastname ?: middleName?:'me'
                 }
             }
         '''
 
-        // Line 7 has two violations because it evaluates the line twice, once for each elvis operator
         assertViolations(SOURCE,
             [lineNumber:4, sourceLineText:"def greeting = fullname?:'you'", messageText:'The operator "?:" within class MyClass is not preceded'],
             [lineNumber:4, sourceLineText:"def greeting = fullname?:'you'", messageText:'The operator "?:" within class MyClass is not followed'],
@@ -225,8 +224,9 @@ class SpaceAroundOperatorRuleTest extends AbstractRuleTestCase<SpaceAroundOperat
             [lineNumber:5, sourceLineText:'def f = funds.collect {it.fundSortOrder}?:[]', messageText:'The operator "?:" within class MyClass is not followed'],
             [lineNumber:6, sourceLineText:'assert model.UserID == expectedModel.UserID?:null', messageText:'The operator "?:" within class MyClass is not preceded'],
             [lineNumber:6, sourceLineText:'assert model.UserID == expectedModel.UserID?:null', messageText:'The operator "?:" within class MyClass is not followed'],
-            [lineNumber:7, sourceLineText: "def doubleElvis = fullname ?:lastname ?: 'me'", messageText:'The operator "?:" within class MyClass is not followed'],
-            [lineNumber:7, sourceLineText: "def doubleElvis = fullname ?:lastname ?: 'me'", messageText:'The operator "?:" within class MyClass is not followed'])
+            [lineNumber:7, sourceLineText: "def tripleElvis = fullname ?:lastname ?: middleName?:'me'", messageText:'The operator "?:" within class MyClass is not followed'],
+            [lineNumber:7, sourceLineText: "def tripleElvis = fullname ?:lastname ?: middleName?:'me'", messageText:'The operator "?:" within class MyClass is not preceded'],
+            [lineNumber:7, sourceLineText: "def tripleElvis = fullname ?:lastname ?: middleName?:'me'", messageText:'The operator "?:" within class MyClass is not followed'])
     }
 
     @Test
@@ -238,6 +238,8 @@ class SpaceAroundOperatorRuleTest extends AbstractRuleTestCase<SpaceAroundOperat
                     'you'
                     def doubleElvis = fullname ?: lastname ?:
                     'me'
+                    def newLineElvis = fullname \
+                    ?: 'you'
                 }
             }
         '''

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceAroundOperatorRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceAroundOperatorRuleTest.groovy
@@ -212,16 +212,36 @@ class SpaceAroundOperatorRuleTest extends AbstractRuleTestCase<SpaceAroundOperat
                     def greeting = fullname?:'you'
                     def f = funds.collect {it.fundSortOrder}?:[]
                     assert model.UserID == expectedModel.UserID?:null
+                    def doubleElvis = fullname ?:lastname ?: 'me'
                 }
             }
         '''
+
+        // Line 7 has two violations because it evaluates the line twice, once for each elvis operator
         assertViolations(SOURCE,
             [lineNumber:4, sourceLineText:"def greeting = fullname?:'you'", messageText:'The operator "?:" within class MyClass is not preceded'],
             [lineNumber:4, sourceLineText:"def greeting = fullname?:'you'", messageText:'The operator "?:" within class MyClass is not followed'],
             [lineNumber:5, sourceLineText:'def f = funds.collect {it.fundSortOrder}?:[]', messageText:'The operator "?:" within class MyClass is not preceded'],
             [lineNumber:5, sourceLineText:'def f = funds.collect {it.fundSortOrder}?:[]', messageText:'The operator "?:" within class MyClass is not followed'],
             [lineNumber:6, sourceLineText:'assert model.UserID == expectedModel.UserID?:null', messageText:'The operator "?:" within class MyClass is not preceded'],
-            [lineNumber:6, sourceLineText:'assert model.UserID == expectedModel.UserID?:null', messageText:'The operator "?:" within class MyClass is not followed'])
+            [lineNumber:6, sourceLineText:'assert model.UserID == expectedModel.UserID?:null', messageText:'The operator "?:" within class MyClass is not followed'],
+            [lineNumber:7, sourceLineText: "def doubleElvis = fullname ?:lastname ?: 'me'", messageText:'The operator "?:" within class MyClass is not followed'],
+            [lineNumber:7, sourceLineText: "def doubleElvis = fullname ?:lastname ?: 'me'", messageText:'The operator "?:" within class MyClass is not followed'])
+    }
+
+    @Test
+    void testApplyTo_ElvisOperatorWithNewLineAsSapce_NoViolation() {
+        final SOURCE = '''
+            class MyClass {
+                def myMethod() {
+                    def greeting = fullname ?:
+                    'you'
+                    def doubleElvis = fullname ?: lastname ?:
+                    'me'
+                }
+            }
+        '''
+        assertNoViolations(SOURCE)
     }
 
     @Test


### PR DESCRIPTION
If there was a newline after an elvis operator, it was throwing a SpaceAfterOperator warning.

Previously the code was set up to make sure at least one elvis operator had a space after it. Unfortunately that meant the following line would have passed:

```groovy
def doubleElvis = fullname ?:lastname ?: 'me'
```

I updated the check if there is instance of an elvis operator with any non-whitespace character following it.

If you like this method, it could be explored if it is causing problems with any other operators too.