### PR TITLE
Add spec to DEFAULT_TEST_FILES and DEFAULT_TEST_CLASS_NAMES

### DIFF
--- a/src/main/java/org/codenarc/rule/AbstractAstVisitorRule.java
+++ b/src/main/java/org/codenarc/rule/AbstractAstVisitorRule.java
@@ -39,8 +39,8 @@ public abstract class AbstractAstVisitorRule extends AbstractRule {
     protected static final String DEFAULT_CONST_NAME = "[A-Z][A-Z0-9_]*";
     protected static final String DEFAULT_FIELD_NAME = "[a-z][a-zA-Z0-9]*";
     protected static final String DEFAULT_VAR_NAME   = "[a-z][a-zA-Z0-9]*";
-    protected static final String DEFAULT_TEST_FILES = ".*(Test|Tests|TestCase)\\.groovy";
-    protected static final String DEFAULT_TEST_CLASS_NAMES = "*Test,*Tests,*TestCase";
+    protected static final String DEFAULT_TEST_FILES = ".*(Spec|Test|Tests|TestCase)\\.groovy";
+    protected static final String DEFAULT_TEST_CLASS_NAMES = "*Spec,*Test,*Tests,*TestCase";
 
     public static final String CLOSURE_TEXT = "{ -> ... }";
 

--- a/src/site/apt/codenarc-rules-design.apt
+++ b/src/site/apt/codenarc-rules-design.apt
@@ -314,7 +314,7 @@ Design Rules  ("<rulesets/design.xml>")
    * {{{http://stackoverflow.com/questions/4192837/how-does-one-use-polymorphism-instead-of-instanceof-and-why}How does one use polymorphism instead of instanceof? (And why?)}}
 
   By default, the rule does not analyze test files. This rule sets the default value of the
-  <doNotApplyToFilesMatching> property to ignore file names ending in 'Test.groovy', 'Tests.groovy'
+  <doNotApplyToFilesMatching> property to ignore file names ending in 'Spec.groovy', 'Test.groovy', 'Tests.groovy'
   or 'TestCase.groovy'.
 
 *-------------------+----------------------------------------------------------------+------------------------+

--- a/src/site/apt/codenarc-rules-dry.apt
+++ b/src/site/apt/codenarc-rules-dry.apt
@@ -21,7 +21,7 @@ DRY (Don't Repeat Yourself) Rules  ("<rulesets/dry.xml>")
   Code containing duplicate <List> literals can usually be improved by declaring the <List> as a constant field.
 
   By default, the rule does not analyze test files. This rule sets the default value of the
-  <doNotApplyToFilesMatching> property to ignore file names ending in 'Test.groovy', 'Tests.groovy'
+  <doNotApplyToFilesMatching> property to ignore file names ending in 'Spec.groovy', 'Test.groovy', 'Tests.groovy'
   or 'TestCase.groovy'.
 
   Examples of violations:
@@ -70,7 +70,7 @@ DRY (Don't Repeat Yourself) Rules  ("<rulesets/dry.xml>")
   Code containing duplicate <Map> literals can usually be improved by declaring the <Map> as a constant field.
 
   By default, the rule does not analyze test files. This rule sets the default value of the
-  <doNotApplyToFilesMatching> property to ignore file names ending in 'Test.groovy', 'Tests.groovy'
+  <doNotApplyToFilesMatching> property to ignore file names ending in 'Spec.groovy', 'Test.groovy', 'Tests.groovy'
   or 'TestCase.groovy'.
 
   Examples of violations:
@@ -124,7 +124,7 @@ DRY (Don't Repeat Yourself) Rules  ("<rulesets/dry.xml>")
   Code containing duplicate <Number> literals can usually be improved by declaring the <Number> as a constant field.
 
   By default, the rule does not analyze test files. This rule sets the default value of the
-  <doNotApplyToFilesMatching> property to ignore file names ending in 'Test.groovy', 'Tests.groovy'
+  <doNotApplyToFilesMatching> property to ignore file names ending in 'Spec.groovy', 'Test.groovy', 'Tests.groovy'
   or 'TestCase.groovy'.
 
 *---------------------+----------------------------------------------------------------+------------------------+
@@ -157,7 +157,7 @@ DRY (Don't Repeat Yourself) Rules  ("<rulesets/dry.xml>")
   Code containing duplicate <String> literals can usually be improved by declaring the <String> as a constant field.
 
   By default, the rule does not analyze test files. This rule sets the default value of the
-  <doNotApplyToFilesMatching> property to ignore file names ending in 'Test.groovy', 'Tests.groovy'
+  <doNotApplyToFilesMatching> property to ignore file names ending in 'Spec.groovy', 'Test.groovy', 'Tests.groovy'
   or 'TestCase.groovy'.
 
 *---------------------+----------------------------------------------------------------+------------------------+

--- a/src/site/apt/codenarc-rules-junit.apt
+++ b/src/site/apt/codenarc-rules-junit.apt
@@ -101,7 +101,7 @@ JUnit Rules  ("<rulesets/junit.xml>")
       * <<<assertNull([a:123])>>>.
 
   This rule sets the default value of the <applyToClassNames> property to only match class names
-  ending in 'Test', 'Tests' or 'TestCase'.
+  ending in 'Spec', 'Test', 'Tests' or 'TestCase'.
 
 
 * {JUnitAssertAlwaysSucceeds} Rule
@@ -133,7 +133,7 @@ JUnit Rules  ("<rulesets/junit.xml>")
         * <<<assertNull(null)>>>
 
   This rule sets the default value of the <applyToClassNames> property to only match class names
-  ending in 'Test', 'Tests' or 'TestCase'.
+  ending in 'Spec', 'Test', 'Tests' or 'TestCase'.
 
 
 * {JUnitFailWithoutMessage} Rule
@@ -155,7 +155,7 @@ JUnit Rules  ("<rulesets/junit.xml>")
   AST Transformations to automatically annotate test methods.
 
   This rule sets the default value of the <applyToClassNames> property to only match class names
-  ending in 'Test', 'Tests' or 'TestCase'.
+  ending in 'Spec', 'Test', 'Tests' or 'TestCase'.
 
   Example of violations:
 
@@ -178,7 +178,7 @@ JUnit Rules  ("<rulesets/junit.xml>")
   Fields within interfaces and fields annotated with @Rule are ignored.
 
   This rule sets the default value of the <applyToClassNames> property to only match class names
-  ending in 'Test', 'Tests' or 'TestCase'.
+  ending in 'Spec', 'Test', 'Tests' or 'TestCase'.
 
   Example of violations:
 
@@ -225,7 +225,7 @@ JUnit Rules  ("<rulesets/junit.xml>")
   and thus be ignored by JUnit.
 
   This rule sets the default value of the <applyToClassNames> property to only match class names
-  ending in 'Test', 'Tests' or 'TestCase'.
+  ending in 'Spec', 'Test', 'Tests' or 'TestCase'.
 
   *------------------------------+-------------------------------------------------------------+----------------------------+
   | <<Property>>                 | <<Description>>                                             | <<Default Value>>          |
@@ -246,7 +246,7 @@ JUnit Rules  ("<rulesets/junit.xml>")
   expose a public property (with public <getter> and <setter> methods) on a test class.
 
   This rule sets the default value of the <applyToClassNames> property to only match class names
-  ending in 'Test', 'Tests' or 'TestCase'.
+  ending in 'Spec', 'Test', 'Tests' or 'TestCase'.
 
 *---------------------+----------------------------------------------------------------+------------------------+
 | <<Property>>        | <<Description>>                                                | <<Default Value>>      |
@@ -280,7 +280,7 @@ JUnit Rules  ("<rulesets/junit.xml>")
   This rule ignored methods annotated with <<<@Before>>> or <<<@BeforeClass>>>.
 
   This rule sets the default value of the <applyToClassNames> property to only match class names
-  ending in 'Test', 'Tests' or 'TestCase'.
+  ending in 'Spec', 'Test', 'Tests' or 'TestCase'.
 
 
 * {JUnitStyleAssertions} Rule
@@ -302,7 +302,7 @@ JUnit Rules  ("<rulesets/junit.xml>")
   This rule ignored methods annotated with <<<@After>>> or <<<@AfterClass>>>.
 
   This rule sets the default value of the <applyToClassNames> property to only match class names
-  ending in 'Test', 'Tests' or 'TestCase'.
+  ending in 'Spec', 'Test', 'Tests' or 'TestCase'.
 
 
 * {JUnitTestMethodWithoutAssert} Rule
@@ -340,7 +340,7 @@ JUnit Rules  ("<rulesets/junit.xml>")
   <<<super.setUp()>>>. The method is then unnecessary.
 
   This rule sets the default value of the <applyToClassNames> property to only match class names
-  ending in 'Test', 'Tests' or 'TestCase'.
+  ending in 'Spec', 'Test', 'Tests' or 'TestCase'.
 
   Here is an example of a violation:
 
@@ -360,7 +360,7 @@ JUnit Rules  ("<rulesets/junit.xml>")
   <<<super.tearDown()>>>. The method is then unnecessary.
 
   This rule sets the default value of the <applyToClassNames> property to only match class names
-  ending in 'Test', 'Tests' or 'TestCase'.
+  ending in 'Spec', 'Test', 'Tests' or 'TestCase'.
 
   Here is an example of a violation:
 
@@ -381,7 +381,7 @@ JUnit Rules  ("<rulesets/junit.xml>")
   Check for <<<throws>>> clauses on JUnit test methods. That is not necessary in Groovy.
 
   This rule sets the default value of the <applyToClassNames> property to only match class names
-  ending in 'Test', 'Tests' or 'TestCase'.
+  ending in 'Spec', 'Test', 'Tests' or 'TestCase'.
 
   Example of violations:
 
@@ -457,7 +457,7 @@ JUnit Rules  ("<rulesets/junit.xml>")
   It is better to rethrow the exception or not catch the exception at all.
 
   This rule sets the default value of the <applyToClassNames> property to only match class names
-  ending in 'Test', 'Tests' or 'TestCase'.
+  ending in 'Spec', 'Test', 'Tests' or 'TestCase'.
 
   Example of violations:
 
@@ -486,7 +486,7 @@ JUnit Rules  ("<rulesets/junit.xml>")
   like <<<assertEquals>>>.
 
   This rule sets the default value of the <applyToClassNames> property to only match class names
-  ending in 'Test', 'Tests' or 'TestCase'.
+  ending in 'Spec', 'Test', 'Tests' or 'TestCase'.
 
 
 * {UseAssertFalseInsteadOfNegation} Rule
@@ -497,7 +497,7 @@ JUnit Rules  ("<rulesets/junit.xml>")
   For instance, <<<assertTrue(!condition)>>> can always be simplified to <<<assertFalse(condition)>>>.
 
   This rule sets the default value of the <applyToClassNames> property to only match class names
-  ending in 'Test', 'Tests' or 'TestCase'.
+  ending in 'Spec', 'Test', 'Tests' or 'TestCase'.
 
 
 * {UseAssertTrueInsteadOfAssertEquals} Rule
@@ -508,7 +508,7 @@ JUnit Rules  ("<rulesets/junit.xml>")
   should be made by more specific methods, like <<<assertTrue>>> or <<<assertFalse>>>.
 
   This rule sets the default value of the <applyToClassNames> property to only match class names
-  ending in 'Test', 'Tests' or 'TestCase'.
+  ending in 'Spec', 'Test', 'Tests' or 'TestCase'.
 
 *---------------------------+----------------------------------------------------------------+------------------------+
 | <<Property>>              | <<Description>>                                                | <<Default Value>>      |
@@ -545,7 +545,7 @@ JUnit Rules  ("<rulesets/junit.xml>")
   For instance, <<<assertFalse(!condition)>>> can always be simplified to <<<assertTrue(condition)>>>.
 
   This rule sets the default value of the <applyToClassNames> property to only match class names
-  ending in 'Test', 'Tests' or 'TestCase'.
+  ending in 'Spec', 'Test', 'Tests' or 'TestCase'.
 
 
 * {UseAssertNullInsteadOfAssertEquals} Rule
@@ -556,7 +556,7 @@ JUnit Rules  ("<rulesets/junit.xml>")
   These assertion should be made against the <<<assertNull>>> method instead.
 
   This rule sets the default value of the <applyToClassNames> property to only match class names
-  ending in 'Test', 'Tests' or 'TestCase'.
+  ending in 'Spec', 'Test', 'Tests' or 'TestCase'.
 
 
 * {UseAssertSameInsteadOfAssertTrue} Rule
@@ -568,5 +568,5 @@ JUnit Rules  ("<rulesets/junit.xml>")
   <<<assertSame>>> or <<<assertNotSame>>> method instead.
 
   This rule sets the default value of the <applyToClassNames> property to only match class names
-  ending in 'Test', 'Tests' or 'TestCase'.
+  ending in 'Spec', 'Test', 'Tests' or 'TestCase'.
 

--- a/src/site/apt/codenarc-rules-unused.apt
+++ b/src/site/apt/codenarc-rules-unused.apt
@@ -105,7 +105,7 @@ Unused Rules  ("<rulesets/unused.xml>")
   include:
 
   By default, this rule does not analyze test files. This rule sets the default value of the
-  <doNotApplyToFilesMatching> property to ignore file names ending in 'Test.groovy', 'Tests.groovy'
+  <doNotApplyToFilesMatching> property to ignore file names ending in 'Spec.groovy, ''Test.groovy', 'Tests.groovy'
   or 'TestCase.groovy'. Invoking constructors without using the result is a common pattern in tests.
 
 -------------------------------------------------------------------------------

--- a/src/test/groovy/org/codenarc/rule/AbstractAstVisitorRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/AbstractAstVisitorRuleTest.groovy
@@ -214,6 +214,7 @@ class AbstractAstVisitorRuleTest extends AbstractRuleTestCase<AbstractAstVisitor
         assert 'MyTest.groovy' ==~ AbstractAstVisitorRule.DEFAULT_TEST_FILES
         assert 'MyTests.groovy' ==~ AbstractAstVisitorRule.DEFAULT_TEST_FILES
         assert 'MyTestCase.groovy' ==~ AbstractAstVisitorRule.DEFAULT_TEST_FILES
+        assert 'MySpec.groovy' ==~ AbstractAstVisitorRule.DEFAULT_TEST_FILES
         assertFalse 'MyNonTestClass.groovy' ==~ AbstractAstVisitorRule.DEFAULT_TEST_FILES
     }
 
@@ -223,6 +224,7 @@ class AbstractAstVisitorRuleTest extends AbstractRuleTestCase<AbstractAstVisitor
         assert wildcardPattern.matches('MyTest')
         assert wildcardPattern.matches('MyTests')
         assert wildcardPattern.matches('MyTestCase')
+        assert wildcardPattern.matches('MySpec')
         assertFalse wildcardPattern.matches('MyNonTestClass')\
     }
 


### PR DESCRIPTION
Since Spec is a standard spock file and and class suffix, it should be set by default with the rest of the standard test files and names.