### PR TITLE
Ignore ClassRule in JUnitPublicFieldRule

### DIFF
--- a/src/main/groovy/org/codenarc/rule/junit/JUnitPublicFieldRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/junit/JUnitPublicFieldRule.groovy
@@ -22,7 +22,7 @@ import org.codenarc.rule.AbstractFieldVisitor
 import org.codenarc.util.AstUtil
 
 /**
- * Checks for public field on a JUnit test class. Ignores fields with the @Rule annotation.
+ * Checks for public field on a JUnit test class. Ignores fields with the @Rule and @ClassRule annotations.
  * <p/>
  * This rule ignores interfaces.
  * <p/>
@@ -49,7 +49,7 @@ class JUnitPublicFieldAstVisitor extends AbstractFieldVisitor {
 
     @Override
     void visitField(FieldNode node) {
-        if (node.isPublic() && !AstUtil.hasAnnotation(node, 'Rule') ) {
+        if (node.isPublic() && !AstUtil.hasAnnotation(node, 'Rule') && !AstUtil.hasAnnotation(node, 'ClassRule')) {
             addViolation(node, "The field $node.name is public. There is usually no reason to have a public field (even a constant) on a test class.")
         }
     }

--- a/src/test/groovy/org/codenarc/rule/junit/JUnitPublicFieldRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/junit/JUnitPublicFieldRuleTest.groovy
@@ -71,6 +71,16 @@ class JUnitPublicFieldRuleTest extends AbstractRuleTestCase<JUnitPublicFieldRule
     }
 
     @Test
+    void testClassWithPublicFieldsAnnotatedWithClassRule_NoViolations() {
+        final SOURCE = '''
+            class MyTestCase {
+                @ClassRule public TestName testName = new TestName()
+            }
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
     void testClassWithPublicFields_Violations() {
         final SOURCE = '''
             import org.junit.Test


### PR DESCRIPTION
`JUnitPublicFieldRule` already ignores the `@Rule` annotation and should also ignore `@ClassRule`.