### PR TITLE
Add ClassStartsWithBlankLine rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Version 1.3
 --------------------------------------
 New Rules
  - #359: **ClassEndsWithBlankLine** rule: Check whether the class ends with a blank line.
- - #360: **ClassStartsWithBlankLine** rule: Check whether the class starts with a blank line.
+ - #362: **ClassStartsWithBlankLine** rule: Check whether the class starts with a blank line.
 
  
 Version 1.2.1 (Aug 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Version 1.3
 --------------------------------------
 New Rules
  - #359: **ClassEndsWithBlankLine** rule: Check whether the class ends with a blank line.
- 
+ - #360: **ClassStartsWithBlankLine** rule: Check whether the class starts with a blank line.
+
  
 Version 1.2.1 (Aug 2018)
 --------------------------------------

--- a/src/main/groovy/org/codenarc/rule/formatting/ClassStartsWithBlankLineRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/ClassStartsWithBlankLineRule.groovy
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codenarc.rule.formatting
+
+import groovy.transform.Memoized
+import org.codehaus.groovy.ast.ClassNode
+import org.codenarc.rule.AbstractAstVisitorRule
+import org.codenarc.rule.AbstractAstVisitor
+import org.codenarc.rule.Violation
+import org.codenarc.util.AstUtil
+
+/**
+ * Check whether the class starts with a blank line. By default, it enforces that there must be a blank line after
+ * the opening class brace, except if the class is empty and is written in a single line. A blank line is defined as
+ * any line that does not contain any visible characters. This rule can be configured with the following properties:
+ * <ul>
+ *  <li><i>ignoreSingleLineClasses</i>: a boolean property to forbid single line classes.
+ *  If it is false, then single line classes are considered a violation. Default value is true</li>
+ *  <li><i>blankLineRequired</i>: a boolean property to define if there may be a blank line after the opening class
+ *  brace. If it is false, the first content after the brace must not be a blank line. Otherwise, it must be a blank
+ *  line. Default value is true</li>
+ * <ul>
+ *
+ * @author David Ausín
+ */
+class ClassStartsWithBlankLineRule extends AbstractAstVisitorRule {
+
+    String name = 'ClassStartsWithBlankLine'
+    int priority = 2
+    Class astVisitorClass = ClassStartsWithBlankLineAstVisitor
+    boolean ignoreSingleLineClasses = true
+    boolean blankLineRequired = true
+}
+
+class ClassStartsWithBlankLineAstVisitor extends AbstractAstVisitor {
+
+    private static final String OPENING_BRACE_CHARACTER = '{'
+
+    @Override
+    protected void visitClassComplete(ClassNode classNode) {
+        if (isSingleLineClassViolation() && isSingleLineClass(classNode)) { return }
+
+        if (rule.blankLineRequired) {
+            checkIfThereIsBlankLineAfterOpeningBrace(classNode)
+        } else {
+            checkIfThereIsNotBlankLineAfterOpeningBrace(classNode)
+        }
+    }
+
+    private void checkIfThereIsNotBlankLineAfterOpeningBrace(ClassNode classNode) {
+        int openingBraceLineNumber = findLineNumberOfClassOpeningBrace(classNode)
+        String openingBraceLine = getLine(openingBraceLineNumber)
+        String charactersAfterOpeningBraceLine = getCharactersAfterFirstOpeningBrace(openingBraceLine)
+        int lineAfterOpeningBraceNumber = openingBraceLineNumber + 1
+        String lineAfterOpeningBrace = getLine(lineAfterOpeningBraceNumber)
+        if (!lineAfterOpeningBrace.trim() && !charactersAfterOpeningBraceLine.trim()) {
+            addViolation('Class starts with a blank line after the opening brace', lineAfterOpeningBraceNumber)
+        }
+    }
+
+    private String getLine(int lineNumber) {
+        AstUtil.getRawLine(sourceCode, lineNumber - 1)
+    }
+
+    private String getCharactersAfterFirstOpeningBrace(String line) {
+        int openBracePosition = line.indexOf(OPENING_BRACE_CHARACTER)
+        if (openBracePosition == -1) {
+            return ''
+        }
+        line.drop(openBracePosition + 1)
+    }
+
+    private int findLineNumberOfClassOpeningBrace(ClassNode classNode) {
+        int linesToOpeningBrace = sourceCode.lines.drop(classNode.lineNumber - 1)
+                .findIndexOf { String currentLine -> currentLine.contains(OPENING_BRACE_CHARACTER) }
+        classNode.lineNumber + linesToOpeningBrace
+    }
+
+    private void checkIfThereIsBlankLineAfterOpeningBrace(ClassNode classNode) {
+        if (isSingleLineClass(classNode)) {
+            addViolation('Single line classes are not allowed', classNode.lineNumber)
+            return
+        }
+
+        int openingBraceLineNumber = findLineNumberOfClassOpeningBrace(classNode)
+        String openingBraceLine = getLine(openingBraceLineNumber)
+        String charactersAfterOpeningBraceLine = getCharactersAfterFirstOpeningBrace(openingBraceLine)
+        int lineAfterOpeningBraceNumber = openingBraceLineNumber + 1
+        String lineAfterOpeningBrace = getLine(lineAfterOpeningBraceNumber)
+        if (charactersAfterOpeningBraceLine.trim()) {
+            addViolation('Class does not start with a blank line after the opening brace',
+                    openingBraceLineNumber)
+            return
+        }
+
+        if (lineAfterOpeningBrace.trim()) {
+            addViolation('Class does not start with a blank line after the opening brace',
+                    lineAfterOpeningBraceNumber)
+        }
+    }
+
+    private boolean isSingleLineClassViolation() {
+        rule.ignoreSingleLineClasses || !rule.blankLineRequired
+    }
+
+    @Memoized
+    private Boolean isSingleLineClass(ClassNode classNode) {
+        return AstUtil.getNodeText(classNode, sourceCode) == AstUtil.getLastLineOfNodeText(classNode, sourceCode)
+    }
+
+    private void addViolation(String message, int lineNumber) {
+        if (lineNumber >= 0) {
+            String sourceLine = getLine(lineNumber)
+            Violation violation = new Violation()
+            violation.rule = rule
+            violation.lineNumber = lineNumber
+            violation.sourceLine = sourceLine
+            violation.message  = message
+            violations.add(violation)
+        }
+    }
+}

--- a/src/main/resources/codenarc-base-messages.properties
+++ b/src/main/resources/codenarc-base-messages.properties
@@ -6,6 +6,13 @@ ClassEndsWithBlankLine.description.html=Check whether the class ends with a blan
    By default, it enforces that there must be a blank line before the closing class brace, except if the class is empty \
   and is written in a single line. A blank line is defined as any line that does not contain any visible characters.
 
+ClassStartsWithBlankLine.description=Check whether the class starts with a blank line. \
+  By default, it enforces that there must be a blank line after the opening class brace, except if the class is empty \
+  and is written in a single line. A blank line is defined as any line that does not contain any visible characters.
+ClassStartsWithBlankLine.description.html=Check whether the class starts with a blank line \
+  By default, it enforces that there must be a blank line after the opening class brace, except if the class is empty \
+  and is written in a single line. A blank line is defined as any line that does not contain any visible characters.
+
 NoJavaUtilDate.description=Do not use java.util.Date. Prefer the classes in the java.time.* packages.
 NoJavaUtilDate.description.html=Do not use java.util.Date. Prefer the classes in the java.time.* packages.
 

--- a/src/main/resources/rulesets/formatting.xml
+++ b/src/main/resources/rulesets/formatting.xml
@@ -40,4 +40,5 @@
     <rule class='org.codenarc.rule.formatting.SpaceBeforeOpeningBraceRule'/>
     <rule class='org.codenarc.rule.formatting.TrailingWhitespaceRule'/>
     <rule class='org.codenarc.rule.formatting.ClassEndsWithBlankLineRule'/>
+    <rule class='org.codenarc.rule.formatting.ClassStartsWithBlankLineRule'/>
 </ruleset>

--- a/src/site/apt/codenarc-rules-formatting.apt
+++ b/src/site/apt/codenarc-rules-formatting.apt
@@ -909,3 +909,65 @@ class MyClass {                                 // CORRECT
 
             }
 -------------------------------------------------------------------------------
+
+* {ClassStartsWithBlankLine} Rule
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  <Since CodeNarc 1.3>
+
+  Check whether the class starts with a blank line. By default, it enforces that there must be a blank line after
+  the opening class brace, except if the class is empty and is written in a single line. A blank line is defined as
+  any line that does not contain any visible characters.
+  This rule can be configured with the following properties:
+
+*----------------------------+----------------------------------------------------------------+------------------------+
+| <<Property>>               | <<Description>>                                                | <<Default Value>>      |
+*----------------------------+----------------------------------------------------------------+------------------------+
+| ignoreSingleLineClasses    | a boolean property to forbid single line classes.If it is      |                        |
+|                            |  false,then single line classes are considered a violation.    | <<<true>>>             |
+*----------------------------+----------------------------------------------------------------+------------------------+
+| blankLineRequired          | a boolean property to define if there may be a blank line      | <<<true>>>             |
+|                            | after the opening class brace. If it is false, the first       |                        |
+|                            | content after the brace must not be a blank line. Otherwise,   |                        |
+|                            | it must be a blank line.                                       |                        |
+*----------------------------+----------------------------------------------------------------+------------------------+
+
+  Example of violations:
+
+  If ignoreSingleLineClasses is <<<true>>> and blankLineRequired is <<<true>>>
+-------------------------------------------------------------------------------
+            class Foo {
+                int a
+
+                void hi() {
+                }
+            }
+-------------------------------------------------------------------------------
+
+  If ignoreSingleLineClasses is <<<false>>> and blankLineRequired is <<<true>>>
+-------------------------------------------------------------------------------
+            class Foo extends Bar<String> { }
+-------------------------------------------------------------------------------
+
+
+  If ignoreSingleLineClasses is <<<true>>> and blankLineRequired is <<<false>>>
+-------------------------------------------------------------------------------
+            class Foo {
+
+                int a
+
+                void hi() {
+                }
+
+            }
+-------------------------------------------------------------------------------
+
+  If ignoreSingleLineClasses is <<<false>>> and blankLineRequired is <<<false>>>
+-------------------------------------------------------------------------------
+            class Foo {
+                int a
+
+                void hi() {
+                }
+
+            }
+-------------------------------------------------------------------------------

--- a/src/test/groovy/org/codenarc/rule/formatting/ClassStartsWithBlankLineRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/ClassStartsWithBlankLineRuleTest.groovy
@@ -1,0 +1,566 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codenarc.rule.formatting
+
+import org.junit.Test
+import org.codenarc.rule.AbstractRuleTestCase
+
+/**
+ * Tests for ClassStartsWithBlankLineRule
+ *
+ * @author David Ausín
+ */
+@SuppressWarnings('TrailingWhitespace')
+class ClassStartsWithBlankLineRuleTest extends AbstractRuleTestCase<ClassStartsWithBlankLineRule> {
+
+    @Test
+    void testRuleProperties() {
+        assert rule.priority == 2
+        assert rule.name == 'ClassStartsWithBlankLine'
+        assert rule.ignoreSingleLineClasses == true
+        assert rule.blankLineRequired == true
+    }
+
+    @Test
+    void testNoViolationsWithSingleClassWhenBlankLineIsRequired() {
+        final String SOURCE = '''
+            class Foo {
+            
+                int a
+                
+                void hi() {
+                }
+
+            }
+        '''
+
+        rule.blankLineRequired = true
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testNoViolationsWithInterfaceClassWhenBlankLineIsRequired() {
+        final String SOURCE = '''
+            interface Foo {
+            
+                void hi()
+
+            }
+        '''
+
+        rule.blankLineRequired = true
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testViolationsWithSingleClassWhenBlankLineIsNotRequired() {
+        final String SOURCE = '''
+            class Foo {
+            
+                int a
+                void hi() {
+                }
+
+            }
+        '''
+
+        rule.blankLineRequired = false
+
+        assertSingleViolation(SOURCE, 3, '')
+    }
+
+    @Test
+    void testViolationsWithInterfaceWhenBlankLineIsNotRequired() {
+        final String SOURCE = '''
+            interface Foo {
+                
+                void hi() 
+
+            }
+        '''
+
+        rule.blankLineRequired = false
+
+        assertSingleViolation(SOURCE, 3, '')
+    }
+
+    @Test
+    void testViolationsWithSingleClassWhenBraceIsNotInANewLineAndBlankLineIsRequired() {
+        final String SOURCE = '''
+        class Foo 
+        {  int a
+            
+            void hi() {
+
+            }        }
+        '''
+
+        rule.blankLineRequired = true
+
+        assertSingleViolation(SOURCE, 3, '        {  int a')
+    }
+
+    @Test
+    void testViolationsWithInterfaceWhenBlankLineIsRequired() {
+        final String SOURCE = '''
+        interface Foo {
+            void hi()
+         }
+        '''
+
+        rule.blankLineRequired = true
+
+        assertSingleViolation(SOURCE, 3, 'void hi()')
+    }
+
+    @Test
+    void testNoViolationsWithSingleClassWhenBraceIsNotInANewLineAndBlankLineIsNotRequired() {
+        final String SOURCE = '''
+        class Foo { int a
+            
+            void hi() {
+
+            }        }
+        '''
+
+        rule.blankLineRequired = false
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testViolationWithSingleClassWhenBlankLineIsNotRequired() {
+        final String SOURCE = '''
+            class Foo {
+                
+                int a
+                
+                void hi() {
+                }
+
+            }
+        '''
+        rule.blankLineRequired = false
+
+        assertSingleViolation(SOURCE, 3, '')
+    }
+
+    @Test
+    void testNoViolationsWithSeveralClassesWhenBlankLineIsRequired() {
+        final String SOURCE = '''
+            class Foo {
+            
+                int a
+                
+                void hi() {
+                }
+
+            }
+            interface Bar {
+                
+                void hi()
+                        
+            }
+        '''
+        rule.blankLineRequired = true
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testViolationsWithSeveralClassesWhenBlankLineIsNotRequired() {
+        final String SOURCE = '''
+            class Foo {
+           
+                int a
+                void hi() {
+                }
+            }
+            class Bar {
+            
+                int a
+                
+                void hi() {
+                }
+            }
+        '''
+        rule.blankLineRequired = false
+
+        assertViolations(SOURCE,
+                [lineNumber: 3, sourceLineText: '', messageText: 'Class starts with a blank line after the opening brace'],
+                [lineNumber: 9, sourceLineText: '', messageText: 'Class starts with a blank line after the opening brace'])
+    }
+
+    @Test
+    void testViolationWithSeveralClassesWhenBlankLineIsRequired() {
+        final String SOURCE = '''
+            class Foo {
+                int a
+                
+                void hi() {
+                }   
+            }
+            
+            class Bar {
+                int a
+                
+                void hi() {
+                }
+            }
+        '''
+        rule.blankLineRequired = true
+
+        assertViolations(SOURCE,
+                [lineNumber    : 3, sourceLineText: '                int a', messageText   : 'Class does not start with a blank line after the opening brace'],
+                [lineNumber    : 10, sourceLineText: '                int a', messageText   : 'Class does not start with a blank line after the opening brace'])
+    }
+
+    @Test
+    void testNoViolationWithSeveralClassesWhenBlankLineIsNotRequired() {
+        final String SOURCE = '''
+            class Foo {
+                int a
+                
+                void hi() {
+                }   
+            }
+            
+            class Bar {
+                int a
+                
+                void hi() {
+                }
+            }
+        '''
+        rule.blankLineRequired = false
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testNoViolationsWithNonStaticInnerClassesWhenBlankLineIsRequired() {
+        final String SOURCE = '''
+            class Foo {
+            
+                int a
+                
+                void hi() {
+                }
+                class Bar {
+                
+                    int a
+                
+                    void hi() {
+                    }
+
+                }
+
+            }
+        '''
+        rule.blankLineRequired = true
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testViolationsWithNonStaticInnerClassesWhenBlankLineIsNotRequired() {
+        final String SOURCE = '''
+            class Foo {
+            
+                int a
+                void hi() {
+                }
+                class Bar {
+                
+                    int a
+                    void hi() {
+                    }
+
+                }
+
+            }
+        '''
+        rule.blankLineRequired = false
+
+        assertViolations(SOURCE,
+                [lineNumber: 3, sourceLineText: '', messageText: 'Class starts with a blank line after the opening brace'],
+                [lineNumber: 8, sourceLineText: '', messageText: 'Class starts with a blank line after the opening brace'])
+    }
+
+    @Test
+    void testViolationsWithNonStaticInnerClassesWhenBlankLineIsRequired() {
+        final String SOURCE = '''
+            class Foo {
+                int a
+                
+                void hi() {
+                }
+                
+                class Bar {
+                    int a
+                
+                    void hi() {
+                    }
+                }
+            }
+        '''
+        rule.blankLineRequired = true
+
+        assertViolations(SOURCE,
+                [lineNumber: 3, sourceLineText: 'int a', messageText: 'Class does not start with a blank line after the opening brace'],
+                [lineNumber: 9, sourceLineText: 'int a', messageText: 'Class does not start with a blank line after the opening brace'])
+    }
+
+    @Test
+    void testNoViolationsWithStaticInnerClassesWhenBlankLineIsRequired() {
+        final String SOURCE = '''
+            class Foo {
+            
+                int a
+                
+                void hi() {
+                }
+                static class Bar {
+                
+                    int a
+                
+                    void hi() {
+                    }
+
+                }
+
+            }
+        '''
+        rule.blankLineRequired = true
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testNoViolationsWithStaticInnerClassesWhenBlankLineIsNotRequired() {
+        final String SOURCE = '''
+            class Foo {
+                int a
+                
+                void hi() {
+                }
+                static class Bar {
+                    int a
+                
+                    void hi() {
+                    }
+                }
+            }
+        '''
+        rule.blankLineRequired = false
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testViolationsWithStaticInnerClassesWhenBlankLineIsRequired() {
+        final String SOURCE = '''
+            class Foo {
+                int a
+                
+                void hi() {
+                }
+                
+                static class Bar {
+                    int a
+                
+                    void hi() {
+                    }
+                }
+            }
+        '''
+        rule.blankLineRequired = true
+
+        assertViolations(SOURCE,
+                [lineNumber: 3, sourceLineText: 'int a', messageText: 'Class does not start with a blank line after the opening brace'],
+                [lineNumber: 9, sourceLineText: 'int a', messageText: 'Class does not start with a blank line after the opening brace'])
+    }
+
+    @Test
+    void testViolationsWithStaticInnerClassesWhenBlankLineIsNotRequired() {
+        final String SOURCE = '''
+            class Foo {
+                int a
+                
+                void hi() {
+                }
+                
+                static class Bar {
+                
+                    int a
+                
+                    void hi() {
+                    }
+                    
+                }
+                
+            }
+        '''
+        rule.blankLineRequired = false
+
+        assertViolations(SOURCE,
+                [lineNumber: 9, sourceLineText: '            ', messageText: 'Class starts with a blank line after the opening brace'])
+    }
+
+    @Test
+    void testNoViolationsWithSingleLineClassesIgnoredWhenBlankLineIsRequired() {
+        final String SOURCE = '''
+            import my.company.Bar
+            class Foo extends Bar<String> { }
+            
+            class Doe extends Bar<String> { }
+        '''
+        rule.blankLineRequired = true
+        rule.ignoreSingleLineClasses = true
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testNoViolationsWithSingleLineClassesIgnoredWhenBlankLineIsNotRequired() {
+        final String SOURCE = '''
+            import my.company.Bar
+            class Foo extends Bar<String> { }
+            
+            class Doe extends Bar<String> { }
+        '''
+        rule.blankLineRequired = false
+        rule.ignoreSingleLineClasses = true
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testViolationsWithSingleLineClassesNotAllowedWhenBlankLineIsRequired() {
+        final String SOURCE = '''
+            import my.company.Bar
+            class Foo extends Bar<String> { }
+
+            class Doe extends Bar<String> { }
+            abstract class John  { abstract void a() }
+        '''
+
+        rule.ignoreSingleLineClasses = false
+        rule.blankLineRequired = true
+
+        assertViolations(SOURCE,
+                [lineNumber    : 3, sourceLineText: 'class Foo extends Bar<String> { }', messageText   : 'Single line classes are not allowed'],
+                [lineNumber    : 5, sourceLineText: 'class Doe extends Bar<String> { }', messageText   : 'Single line classes are not allowed'],
+                [lineNumber    : 6, sourceLineText: 'abstract class John  { abstract void a() }', messageText   : 'Single line classes are not allowed'])
+    }
+
+    @Test
+    void testNoViolationsWithSingleLineClassesNotAllowedWhenBlankLineIsNotRequired() {
+        final String SOURCE = '''
+            import my.company.Bar
+            class Foo extends Bar<String> { }
+
+            class Doe extends Bar<String> { }
+            abstract class John  { abstract void a() }
+        '''
+
+        rule.ignoreSingleLineClasses = false
+        rule.blankLineRequired = false
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testNoViolationsWithAnonymousClassesWhenBlankLineIsRequired() {
+        final String SOURCE = '''
+            class Foo { 
+            
+                Bar a = new Bar() {
+                    
+                    @Override
+                    String toString() {
+                        "Hello world"
+                    }
+
+                }
+
+            }            
+        '''
+        rule.blankLineRequired = true
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testNoViolationsWithAnonymousClassesWhenBlankLineIsNotRequired() {
+        final String SOURCE = '''
+            class Foo { Bar a = new Bar() {
+                    @Override
+                    String toString() {
+                        "Hello world"
+                    }
+                }
+            }            
+        '''
+        rule.blankLineRequired = false
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testViolationsWithAnonymousClassesWhenBlankLineIsRequired() {
+        final String SOURCE = '''
+            class Foo { 
+            
+                Bar a = new Bar() {        
+                    @Override
+                    String toString() {
+                        "Hello world"
+                    }
+                }
+
+            }            
+        '''
+        rule.blankLineRequired = true
+
+        assertSingleViolation(SOURCE, 5, '@Override')
+    }
+
+    @Test
+    void testViolationsWithAnonymousClassesWhenBlankLineIsNotRequired() {
+        final String SOURCE = '''
+            class Foo { 
+                Bar a = new Bar() {
+                    
+                    @Override
+                    String toString() {
+                        "Hello world"
+                    }
+                    
+                }
+            }            
+        '''
+        rule.blankLineRequired = false
+        assertSingleViolation(SOURCE, 4, '')
+    }
+
+    @Override
+    protected ClassStartsWithBlankLineRule createRule() {
+        new ClassStartsWithBlankLineRule()
+    }
+}

--- a/src/test/resources/RunCodeNarcAgainstProjectSourceCode.ruleset
+++ b/src/test/resources/RunCodeNarcAgainstProjectSourceCode.ruleset
@@ -43,6 +43,7 @@ ruleset {
         exclude 'SpaceAfterWhile'
         exclude 'SpaceAroundMapEntryColon'
         exclude 'ClassEndsWithBlankLine'
+        exclude 'ClassStartsWithBlankLine'
     }
 
     ruleset('rulesets/imports.xml') {


### PR DESCRIPTION
Check whether the class starts with a blank line. By default, it enforces that there must be a blank line after the opening class brace, except if the class is empty and is written in a single line. A blank line is defined as any line that does not contain any visible characters. 