### PR TITLE
Make the DuplicateImports rule operate on whole lines.

### DIFF
--- a/src/main/groovy/org/codenarc/rule/imports/AbstractImportRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/imports/AbstractImportRule.groovy
@@ -26,8 +26,8 @@ import org.codenarc.source.SourceCode
  */
 abstract class AbstractImportRule extends AbstractRule {
 
-    public static final String NON_STATIC_IMPORT_PATTERN = /^\s*import(?!\s+static)\s+(\w+(\.\w+)*)\b.*/
-    public static final String STATIC_IMPORT_PATTERN = /^\s*import\s+static\s+(\w+(\.\w+)*)\b.*/
+    public static final String NON_STATIC_IMPORT_PATTERN = /^\s*import(?!\s+static)\s+.*/
+    public static final String STATIC_IMPORT_PATTERN = /^\s*import\s+static\s+.*/
 
     /**
      * Optimization: Stop checking lines for imports once a class/interface has been declared

--- a/src/main/groovy/org/codenarc/rule/imports/DuplicateImportRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/imports/DuplicateImportRule.groovy
@@ -45,12 +45,11 @@ class DuplicateImportRule extends AbstractImportRule {
     private void checkImport(String line, int lineNumber, Set importNames, List violations) {
         def importMatcher = line =~ NON_STATIC_IMPORT_PATTERN
         if (importMatcher) {
-            def importName = importMatcher[0][1]
-            if (importNames.contains(importName)) {
+            if (importNames.contains(line)) {
                 violations.add(new Violation(rule: this, sourceLine: line.trim(), lineNumber: lineNumber))
             }
             else {
-                importNames.add(importName)
+                importNames.add(line)
             }
         }
     }
@@ -58,12 +57,11 @@ class DuplicateImportRule extends AbstractImportRule {
     private void checkStaticImport(String line, int lineNumber, Set staticImportNames, List violations) {
         def importMatcher = line =~ STATIC_IMPORT_PATTERN
         if (importMatcher) {
-            def staticImportName = importMatcher[0][1]
-            if (staticImportNames.contains(staticImportName)) {
+            if (staticImportNames.contains(line)) {
                 violations.add(new Violation(rule: this, sourceLine: line.trim(), lineNumber: lineNumber))
             }
             else {
-                staticImportNames.add(staticImportName)
+                staticImportNames.add(line)
             }
         }
     }

--- a/src/test/groovy/org/codenarc/rule/imports/DuplicateImportRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/imports/DuplicateImportRuleTest.groovy
@@ -119,6 +119,15 @@ class DuplicateImportRuleTest extends AbstractRuleTestCase<DuplicateImportRule> 
         assertNoViolations(SOURCE)
     }
 
+    @Test
+    void testApplyTo_PolishLettersUsedInNames_NoViolations() {
+        final SOURCE = '''
+            import static PolishEnum.PÓŁ
+            import static PolishEnum.DWA_I_PÓŁ
+        '''
+        assertNoViolations(SOURCE)
+    }
+
     @Override
     protected DuplicateImportRule createRule() {
         new DuplicateImportRule()


### PR DESCRIPTION
Duplicated imports rule should care less what's the content
 of the import statement and just report duplications.

This way it is future proof for any changes in import
statement specification and doesn't block the usage of
languages' diacritical characters in java code.