### PR TITLE
Fix compilation of Groovy class in incorrect folder

### DIFF
--- a/src/main/java/org/codenarc/rule/AbstractEnhanceableAstVisitorRule.java
+++ b/src/main/java/org/codenarc/rule/AbstractEnhanceableAstVisitorRule.java
@@ -1,18 +1,18 @@
-package org.codenarc.rule
+package org.codenarc.rule;
 
-import org.codehaus.groovy.control.Phases
+import org.codehaus.groovy.control.Phases;
 
 /**
  * Abstract superclass for Rules that use a Groovy AST Visitor and can optionally run in enhanced mode.
  *
  * @author Marcin Erdmann
  */
-abstract class AbstractEnhanceableAstVisitorRule extends AbstractAstVisitorRule {
+public abstract class AbstractEnhanceableAstVisitorRule extends AbstractAstVisitorRule {
 
     /**
      * Holds the name of the system property which allows to control the {@code enhancedMode} property.
      */
-    public final static String ENHANCED_MODE_SYSTEM_PROPERTY = 'org.codenarc.enhancedMode'
+    public final static String ENHANCED_MODE_SYSTEM_PROPERTY = "org.codenarc.enhancedMode";
 
     /**
      * Controls weather to run in enhanced mode.
@@ -23,11 +23,19 @@ abstract class AbstractEnhanceableAstVisitorRule extends AbstractAstVisitorRule 
      * This property is set to {@code false} by default and can be also controlled using
      * {@code org.codenarc.enhancedMode} system property.
      */
-    boolean enhancedMode = Boolean.getBoolean(ENHANCED_MODE_SYSTEM_PROPERTY)
+    private boolean enhancedMode = Boolean.getBoolean(ENHANCED_MODE_SYSTEM_PROPERTY);
+
+    public boolean isEnhancedMode() {
+        return enhancedMode;
+    }
+
+    public void setEnhancedMode(boolean enhancedMode) {
+        this.enhancedMode = enhancedMode;
+    }
 
     @Override
-    int getCompilerPhase() {
-        enhancedMode ? Phases.SEMANTIC_ANALYSIS : super.compilerPhase
+    public int getCompilerPhase() {
+        return enhancedMode ? Phases.SEMANTIC_ANALYSIS : super.getCompilerPhase();
     }
 
 }


### PR DESCRIPTION
For Gradle this wasn't a problem but compilation failed under Eclipse.
Therefore convert the only Groovy class in src/main/java to a Java class.