### PR TITLE
IndentationRule: Add test on an array containing a closure param

### DIFF
--- a/src/test/groovy/org/codenarc/rule/formatting/IndentationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/IndentationRuleTest.groovy
@@ -774,6 +774,20 @@ class IndentationRuleTest extends AbstractRuleTestCase<IndentationRule> {
     }
 
     @Test
+    void test_Array_ClosureAsParam() {
+        final SOURCE = '''
+            |[
+            |    a {
+            |        b
+            |    }
+            |]
+        '''.stripMargin()
+        // TODO: Fix the code to have no violation
+        assertViolations(SOURCE,
+                [lineNumber:4, sourceLineText:'b', messageText:'The statement on line 4 in class None is at the incorrect indent level: Expected column 5 but was 9'])
+    }
+
+    @Test
     void test_Script() {
         final SOURCE = '''
             |println 1234


### PR DESCRIPTION
This commit is just here to illustrate a bug