### PR TITLE
Add new convention rule for CompileStatic

### DIFF
--- a/src/main/groovy/org/codenarc/rule/convention/CompileStaticRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/convention/CompileStaticRule.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package org.codenarc.rule.convention
 
-import groovy.transform.CompileStatic
 import org.codehaus.groovy.ast.AnnotationNode
 import org.codehaus.groovy.ast.ClassNode
 import org.codehaus.groovy.ast.InnerClassNode
@@ -28,14 +27,15 @@ import org.codenarc.rule.AbstractAstVisitorRule
  *
  * @Author Sudhir Nimavat
  */
-@CompileStatic
 class CompileStaticRule extends AbstractAstVisitorRule {
+
     int priority = 2
     String name = 'CompileStatic'
     Class astVisitorClass = CompileStaticlVisitor
 }
 
 class CompileStaticlVisitor extends AbstractAstVisitor {
+
     private static final String GRAILS_COMPILE_STATIC = 'GrailsCompileStatic'
     private static final String COMPILE_STATIC = 'CompileStatic'
     private static final String COMPILE_DYNAMIC = 'CompileDynamic'

--- a/src/main/groovy/org/codenarc/rule/convention/CompileStaticRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/convention/CompileStaticRule.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codenarc.rule.convention
+
+import groovy.transform.CompileStatic
+import org.codehaus.groovy.ast.AnnotationNode
+import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.ast.InnerClassNode
+import org.codenarc.rule.AbstractAstVisitor
+import org.codenarc.rule.AbstractAstVisitorRule
+
+/**
+ * Enforces classes are annotated either with one of the CompileStatic, GrailsCompileStatic or CompileDynamic
+ * annotations
+ *
+ * @Author Sudhir Nimavat
+ */
+@CompileStatic
+class CompileStaticRule extends AbstractAstVisitorRule {
+    int priority = 2
+    String name = 'CompileStatic'
+    Class astVisitorClass = CompileStaticlVisitor
+}
+
+class CompileStaticlVisitor extends AbstractAstVisitor {
+    private static final String GRAILS_COMPILE_STATIC = 'GrailsCompileStatic'
+    private static final String COMPILE_STATIC = 'CompileStatic'
+    private static final String COMPILE_DYNAMIC = 'CompileDynamic'
+
+    private static final String ERROR_MSG = 'Class should be marked with one of @GrailsCompileStatic, @CompileStatic or @CompileDynamic'
+
+    @Override
+    void visitClassEx(ClassNode classNode) {
+        boolean isExplicitlyMarked = false
+
+        if (!classNode.isInterface() && !(classNode instanceof InnerClassNode)) {
+            for (AnnotationNode annotationNode : classNode.annotations) {
+                String annotation = annotationNode.classNode.text
+                if (annotation in [GRAILS_COMPILE_STATIC, COMPILE_STATIC, COMPILE_DYNAMIC]) {
+                    isExplicitlyMarked = true
+                }
+            }
+
+            if (!isExplicitlyMarked) {
+                addViolation(classNode, ERROR_MSG)
+            }
+        }
+
+        super.visitClassEx(classNode)
+    }
+
+}

--- a/src/main/resources/codenarc-base-messages.properties
+++ b/src/main/resources/codenarc-base-messages.properties
@@ -1159,6 +1159,10 @@ NoTabCharacter.description.html=Checks that all source files do not contain the 
 CouldBeSwitchStatement.description=Checks for multiple if statements that could be converted to a switch
 CouldBeSwitchStatement.description.html=Checks for multiple if statements that could be converted to a switch
 
+CompileStatic.description=Check that classes are explicitely annotated with either @GrailsCompileStatic, @CompileStatic or @CompileDynamic
+CompileStatic.description.html=Check that classes are explicitely annotated with either @GrailsCompileStatic, @CompileStatic or @CompileDynamic
+
+
 #-----------------------------------------------------------------------------------------
 # Report labels, etc.
 #-----------------------------------------------------------------------------------------

--- a/src/main/resources/codenarc-base-rules.properties
+++ b/src/main/resources/codenarc-base-rules.properties
@@ -375,3 +375,4 @@ VolatileArrayField = org.codenarc.rule.concurrency.VolatileArrayFieldRule
 VolatileLongOrDoubleField = org.codenarc.rule.concurrency.VolatileLongOrDoubleFieldRule
 WaitOutsideOfWhileLoop = org.codenarc.rule.concurrency.WaitOutsideOfWhileLoopRule
 WhileStatementBraces = org.codenarc.rule.braces.WhileStatementBracesRule
+CompileStatic = org.codenarc.rule.convention.CompileStaticRule

--- a/src/main/resources/rulesets/convention.xml
+++ b/src/main/resources/rulesets/convention.xml
@@ -30,5 +30,5 @@
     <rule class='org.codenarc.rule.convention.TrailingCommaRule'/>
     <rule class='org.codenarc.rule.convention.VariableTypeRequiredRule'/>
     <rule class='org.codenarc.rule.convention.VectorIsObsoleteRule'/>
-
+    <rule class='org.codenarc.rule.convention.CompileStaticRule'/>
 </ruleset>

--- a/src/test/groovy/org/codenarc/rule/convention/CompileStaticRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/CompileStaticRuleTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,8 @@ import org.junit.Test
  * @author Sudhir Nimavat
  */
 class CompileStaticRuleTest extends AbstractRuleTestCase {
-    boolean  skipTestThatUnrelatedCodeHasNoViolations = true
+
+    boolean skipTestThatUnrelatedCodeHasNoViolations = true
 
     @Override
     protected Rule createRule() {
@@ -89,6 +90,42 @@ class CompileStaticRuleTest extends AbstractRuleTestCase {
                 class AnInnerClass { }
             }
          '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testEnum() {
+        final SOURCE = 'enum Test { OPTION_ONE, OPTION_TWO  }'
+
+        assertSingleViolation(SOURCE) { Violation violation ->
+            violation.rule.priority == 2
+            violation.rule.name == 'CompileStatic'
+        }
+
+        SOURCE = '''
+            import groovy.transform.CompileStatic
+            @CompileStatic
+            enum Test { OPTION_ONE, OPTION_TWO  }
+          '''
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testAbstractClass() {
+        final SOURCE = 'abstract class Test { }'
+
+        assertSingleViolation(SOURCE) { Violation violation ->
+            violation.rule.priority == 2
+            violation.rule.name == 'CompileStatic'
+        }
+
+        SOURCE = '''
+            import groovy.transform.CompileStatic
+            @CompileStatic
+            abstract class Test { }
+          '''
+
         assertNoViolations(SOURCE)
     }
 }

--- a/src/test/groovy/org/codenarc/rule/convention/CompileStaticRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/CompileStaticRuleTest.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codenarc.rule.convention
+
+import org.codenarc.rule.AbstractRuleTestCase
+import org.codenarc.rule.Rule
+import org.codenarc.rule.Violation
+import org.junit.Test
+
+/**
+ * Tests for CompileStatic rule.
+ *
+ * @author Sudhir Nimavat
+ */
+class CompileStaticRuleTest extends AbstractRuleTestCase {
+    boolean  skipTestThatUnrelatedCodeHasNoViolations = true
+
+    @Override
+    protected Rule createRule() {
+        return new CompileStaticRule()
+    }
+
+    @Test
+    void testClassWithoutExplicitCompileStaticNotAllowed() {
+        final SOURCE = 'class Test {  }'
+
+        assertSingleViolation(SOURCE) { Violation violation ->
+            violation.rule.priority == 2
+            violation.rule.name == 'CompileStatic'
+        }
+    }
+
+    @Test
+    void testClassWithGrailsCompileStaticIsAllowed() {
+        final SOURCE = '''
+            import grails.compiler.GrailsCompileStatic
+            @GrailsCompileStatic
+            class Test { }
+         '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testClassWithCompileStaticIsAllowed() {
+        final SOURCE = '''
+            import groovy.transform.CompileStatic
+            @CompileStatic
+            class Test { }
+         '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testClassWithCompileDynamicIsAllowed() {
+        final SOURCE = '''
+            import groovy.transform.CompileDynamic
+            @CompileDynamic
+            class Test { }
+         '''
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testInterfaceIsNotChecked() {
+        final SOURCE = 'interface Test { }'
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testInnerClasseIsNotChecked() {
+        final SOURCE = '''
+            import groovy.transform.CompileDynamic
+            @CompileDynamic
+            class Test {
+                class AnInnerClass { }
+            }
+         '''
+        assertNoViolations(SOURCE)
+    }
+}

--- a/src/test/resources/RunCodeNarcAgainstProjectSourceCode.ruleset
+++ b/src/test/resources/RunCodeNarcAgainstProjectSourceCode.ruleset
@@ -13,6 +13,7 @@ ruleset {
 
     ruleset('rulesets/convention.xml') {
         exclude 'NoDef'
+        exclude 'CompileStatic'
         exclude 'NoJavaUtilDate'
         exclude 'PublicMethodsBeforeNonPublicMethods'
         exclude 'StaticMethodsBeforeInstanceMethods'


### PR DESCRIPTION
Add new CompileStatic rule which can be used to ensure that classes are annotated with compile static. and if the class does not need to be compile static, it has to be explicitely annotated with @CompileDynamic 