### PR TITLE
Update doc

### DIFF
--- a/src/site/apt/codenarc-other-tools-frameworks.apt
+++ b/src/site/apt/codenarc-other-tools-frameworks.apt
@@ -34,7 +34,7 @@ CodeNarc - Integration with Other Tools / Frameworks
       includes reporting and trending of CodeNarc violations. Also see this
       {{{http://blogs.techworld.com/monitoring-the-pulse-of-it/2010/08/grails-hudson-part-1-codenarc/}blog post}}. COMING SOON.
 
-    * {{{http://www.sonarsource.org/}Sonar}} - The {{{http://docs.codehaus.org/display/SONAR/Groovy+Plugin}Sonar Groovy Plugin}}
+    * {{{https://www.sonarqube.org/}SonarQube}} - The {{{https://redirect.sonarsource.com/plugins/groovy.html}Sonar Groovy Plugin}}
       uses CodeNarc for its static analysis of Groovy source code.
 
 

--- a/src/site/apt/codenarc-other-tools-frameworks.apt
+++ b/src/site/apt/codenarc-other-tools-frameworks.apt
@@ -30,9 +30,9 @@ CodeNarc - Integration with Other Tools / Frameworks
 
     * {{{http://maven.apache.org/}Maven}} - See the {{{https://github.com/gleclaire/codenarc-maven-plugin}Maven CodeNarc Plugin}}
 
-    * {{{http://hudson-ci.org/}Hudson}} - The {{{http://wiki.hudson-ci.org/display/HUDSON/Violations}Hudson Violations Plugin}}
-      includes reporting and trending of CodeNarc violations. Also see this
-      {{{http://blogs.techworld.com/monitoring-the-pulse-of-it/2010/08/grails-hudson-part-1-codenarc/}blog post}}. COMING SOON.
+    * {{{https://jenkins.io/}Jenkins}} - The
+      {{{https://github.com/jenkinsci/warnings-ng-plugin#jenkins-warnings-next-generation-plugin}Jenkins Warnings NG Plugin}}
+      includes reporting and trending of CodeNarc violations.
 
     * {{{https://www.sonarqube.org/}SonarQube}} - The {{{https://redirect.sonarsource.com/plugins/groovy.html}Sonar Groovy Plugin}}
       uses CodeNarc for its static analysis of Groovy source code.

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -65,7 +65,7 @@ Static Analysis for Groovy: Less Bugs, Better Code
                    <a href="codenarc-other-tools-frameworks.html">Gradle</a>, <a href="codenarc-other-tools-frameworks.html">Grails</a>,
                    <a href="codenarc-other-tools-frameworks.html">Griffon</a>,
                    <a href="codenarc-other-tools-frameworks.html">SonarQube</a>
-                   and <a href="codenarc-other-tools-frameworks.html">Hudson</a>. See our
+                   and <a href="codenarc-other-tools-frameworks.html">Jenkins</a>. See our
                     <a href="codenarc-other-tools-frameworks.html">Integration</a> page for more details.
                Reports come in HTML, XML, or text format.  Take a look at a
                <a href="SampleCodeNarcHtmlReport.html">Sample CodeNarc HTML Report</a>,

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -63,7 +63,8 @@ Static Analysis for Groovy: Less Bugs, Better Code
                  <a href="codenarc-run-as-a-test.html">as part of your test suite</a>.
                     Also,  plugins exist for <a href="codenarc-other-tools-frameworks.html">Maven</a>,
                    <a href="codenarc-other-tools-frameworks.html">Gradle</a>, <a href="codenarc-other-tools-frameworks.html">Grails</a>,
-                    <a href="codenarc-other-tools-frameworks.html">Griffon</a>, <a href="codenarc-other-tools-frameworks.html">Sonar</a>
+                   <a href="codenarc-other-tools-frameworks.html">Griffon</a>,
+                   <a href="codenarc-other-tools-frameworks.html">SonarQube</a>
                    and <a href="codenarc-other-tools-frameworks.html">Hudson</a>. See our
                     <a href="codenarc-other-tools-frameworks.html">Integration</a> page for more details.
                Reports come in HTML, XML, or text format.  Take a look at a


### PR DESCRIPTION
Since I just released a new SonarQube Groovy plugin, this fixes the links to point to my new version.

While I was at it, I replaced Hudson with Jenkins and recommend an active plugin for that. I didn't touch the  `InlineXmlReportWriter` since that looks specific to the old Violations plugin... (Maybe it can be deprecated/removed?)