### PR TITLE
Improve NoJavaUtilDateRule to also raise violations on usages of deprecated static methods from java.util.Date

### DIFF
--- a/src/main/groovy/org/codenarc/rule/convention/NoJavaUtilDateRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/convention/NoJavaUtilDateRule.groovy
@@ -18,8 +18,10 @@ package org.codenarc.rule.convention
 import org.codehaus.groovy.ast.ImportNode
 import org.codehaus.groovy.ast.ModuleNode
 import org.codehaus.groovy.ast.expr.ConstructorCallExpression
+import org.codehaus.groovy.ast.expr.MethodCallExpression
 import org.codenarc.rule.AbstractAstVisitor
 import org.codenarc.rule.AbstractAstVisitorRule
+import org.codenarc.util.AstUtil
 
 /**
  * Do not use java.util.Date. Prefer the classes in the java.time.* packages. This rule checks for
@@ -49,6 +51,15 @@ class NoJavaUtilDateAstVisitor extends AbstractAstVisitor {
             }
         }
         super.visitConstructorCallExpression(call)
+    }
+
+    @Override
+    void visitMethodCallExpression(MethodCallExpression call) {
+        if (isFirstVisit(call) && !importsDateClass) {
+            if (AstUtil.isMethodCall(call, 'Date', 'parse', 1) || AstUtil.isMethodCall(call, 'Date', 'UTC', 6)) {
+                addViolation(call, VIOLATION_MESSAGE)
+            }
+        }
     }
 
     @Override

--- a/src/test/groovy/org/codenarc/rule/convention/NoJavaUtilDateRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/NoJavaUtilDateRuleTest.groovy
@@ -80,6 +80,39 @@ class NoJavaUtilDateRuleTest extends AbstractRuleTestCase<NoJavaUtilDateRule> {
                 [lineNumber:5, sourceLineText:'Date myDate = new java.util.Date()', messageText:VIOLATION_MESSAGE])
     }
 
+    @Test
+    void test_UsingDeprecatedStaticFactoryMethods_Violations() {
+        final SOURCE = '''
+            def parsedDate = Date.parse("12 Aug 1995 13:30:00")​
+            def utcMillisSinceEpoch = Date.UTC(2020, 1, 25, 17, 19, 0)
+        '''
+        assertViolations(SOURCE,
+            [lineNumber:2, sourceLineText:'def parsedDate = Date.parse("12 Aug 1995 13:30:00")​', messageText:VIOLATION_MESSAGE],
+            [lineNumber:3, sourceLineText:'def utcMillisSinceEpoch = Date.UTC(2020, 1, 25, 17, 19, 0)', messageText:VIOLATION_MESSAGE]
+        )
+    }
+
+    @Test
+    void test_UsingDeprecatedStaticFactoryMethodsButOnCustomDateClass_NoViolations() {
+        final SOURCE = '''
+            import some.other.Date
+
+            def parsedDate = Date.parse("12 Aug 1995 13:30:00")​
+            def utcMillisSinceEpoch = Date.UTC(2020, 1, 25, 17, 19, 0)
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void test_UsingConversionMethodFromInstant_NoViolation() {
+        final SOURCE = '''
+            import java.time.Instant
+
+            Date.from(Instant.now())
+        '''
+        assertNoViolations(SOURCE)
+    }
+
     @Override
     protected NoJavaUtilDateRule createRule() {
         new NoJavaUtilDateRule()


### PR DESCRIPTION
Fixes #454.