### PR TITLE
#455: SpaceBeforeOpeningBrace rule: Fix false-positive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ src/main/java/META-INF/
 /.gradle
 /classes
 /out
+/integration-test/out/test/classes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Updated/Enhanced Rules and Bug Fixes
  - #451: **GetterMethodCouldBeProperty** rule: Do not treat static non-final fields as constants, only static final fields. 
  - #452: **SpaceAfterClosingBrace** rule: Do not complain if closure is used as switch-case condition (allow colon after closure).
  - #456: **NoJavaUtilDate** rule: Also raise violations on usages of deprecated static methods from java.util.Date. (Marcin Erdmann)
+ - #455: **SpaceBeforeOpeningBrace** rule: Fix false-positive when there is an earlier opening brace on the same line.
 
 Framework and Infrastructure
  - #446: Upgrade to Groovy 2.4.17.

--- a/src/main/groovy/org/codenarc/rule/formatting/SpaceBeforeOpeningBraceRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/SpaceBeforeOpeningBraceRule.groovy
@@ -48,7 +48,7 @@ class SpaceBeforeOpeningBraceAstVisitor extends AbstractSpaceAroundBraceAstVisit
     @Override
     protected void visitClassEx(ClassNode node) {
         def line = sourceLineOrEmpty(node)
-        def indexOfBrace = line.indexOf('{')
+        def indexOfBrace = line.indexOf('{', node.columnNumber)
         if (indexOfBrace > 1) {
             if (isNotWhitespace(line, indexOfBrace)) {
                 def typeName = node.isInterface() ? 'interface' : (node.isEnum() ? 'enum' : 'class')

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceBeforeOpeningBraceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceBeforeOpeningBraceRuleTest.groovy
@@ -265,6 +265,14 @@ c        '''
         ''')
     }
 
+    @Test
+    void testApplyTo_ClosureOnSameLine_NoViolations() {
+        final SOURCE = '''
+            new LazyReferenceByFunction<Object, Object>({ null }) { }
+        '''
+        assertNoViolations(SOURCE)
+    }
+
     @Override
     protected SpaceBeforeOpeningBraceRule createRule() {
         new SpaceBeforeOpeningBraceRule()


### PR DESCRIPTION
SpaceBeforeOpeningBrace rule: Fix false-positive when there is an earlier opening brace on the same line.