### PR TITLE
ClassStartsWithBlankLine rule now supports annotations with closures

### DIFF
--- a/src/test/groovy/org/codenarc/rule/formatting/ClassStartsWithBlankLineRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/ClassStartsWithBlankLineRuleTest.groovy
@@ -627,6 +627,24 @@ class ClassStartsWithBlankLineRuleTest extends AbstractRuleTestCase<ClassStartsW
     }
 
     @Test
+    void testViolationsWithSingleClassWhenAnnotationContainsOpeningBrace() {
+        final String SOURCE = '''
+            @Requires({ sys[test] == 'dummy' })
+            class Foo {
+                int a
+
+                void hi() {
+                }
+
+            }
+        '''
+
+        rule.blankLineRequired = true
+
+        assertSingleViolation(SOURCE, 4, '')
+    }
+
+    @Test
     void testNoViolationsWithSingleClassWithSimpleAnnotation() {
         final String SOURCE = '''
             @ToString
@@ -643,6 +661,24 @@ class ClassStartsWithBlankLineRuleTest extends AbstractRuleTestCase<ClassStartsW
         rule.blankLineRequired = true
 
         assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testViolationsWithSingleClassWithSimpleAnnotation() {
+        final String SOURCE = '''
+            @ToString
+            class Foo {
+                int a
+
+                void hi() {
+                }
+
+            }
+        '''
+
+        rule.blankLineRequired = true
+
+        assertSingleViolation(SOURCE, 4, '')
     }
 
     @Test

--- a/src/test/groovy/org/codenarc/rule/formatting/ClassStartsWithBlankLineRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/ClassStartsWithBlankLineRuleTest.groovy
@@ -607,6 +607,133 @@ class ClassStartsWithBlankLineRuleTest extends AbstractRuleTestCase<ClassStartsW
         assertNoViolations(SOURCE)
     }
 
+    @Test
+    void testNoViolationsWithSingleClassWhenAnnotationContainsOpeningBrace() {
+        final String SOURCE = '''
+            @Requires({ sys[test] == 'dummy' })
+            class Foo {
+
+                int a
+
+                void hi() {
+                }
+
+            }
+        '''
+
+        rule.blankLineRequired = true
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testNoViolationsWithSingleClassWithSimpleAnnotation() {
+        final String SOURCE = '''
+            @ToString
+            class Foo {
+
+                int a
+
+                void hi() {
+                }
+
+            }
+        '''
+
+        rule.blankLineRequired = true
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testNoViolationsWithSingleClassWhenAnnotationContainsOpeningBraceAndOnSameLineAsClass() {
+        final String SOURCE = '''
+            @Requires({ sys[test] == 'dummy' }) class Foo {
+
+                int a
+
+                void hi() {
+                }
+
+            }
+        '''
+
+        rule.blankLineRequired = true
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testNoViolationsWithSingleClassWhenAnnotationContainsOpeningBraceAndOnSameLineAsClass_WithTwoAnnotations() {
+        final String SOURCE = '''
+            @Stuff @Requires({ sys[test] == 'dummy' }) class Foo {
+
+                int a
+
+                void hi() {
+                }
+
+            }
+        '''
+
+        rule.blankLineRequired = true
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testNoViolationsWithSingleClassWhenAnnotationContainsOpeningBraceAndOnSameLineAsClass_WithTwoAnnotations_ReverseOrderingOfAnnotations() {
+        final String SOURCE = '''
+            @Requires({ sys[test] == 'dummy' }) @Stuff  class Foo {
+
+                int a
+
+                void hi() {
+                }
+
+            }
+        '''
+
+        rule.blankLineRequired = true
+
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testViolationsWithSingleClassWhenAnnotationContainsOpeningBraceAndOnSameLineAsClass_WithTwoAnnotations_WhenBlankLineIsNotRequired() {
+        final String SOURCE = '''
+            @Stuff @Requires({ sys[test] == 'dummy' }) class Foo {
+
+                int a
+
+                void hi() {
+                }
+
+            }
+        '''
+
+        rule.blankLineRequired = false
+
+        assertSingleViolation(SOURCE, 3, '')
+    }
+
+    @Test
+    void testViolationsWithSingleClassWhenAnnotationContainsOpeningBraceAndOnSameLineAsClass() {
+        final String SOURCE = '''
+            @Requires({ sys[test] == 'dummy' }) class Foo {
+                int a
+
+                void hi() {
+                }
+
+            }
+        '''
+
+        rule.blankLineRequired = true
+
+        assertSingleViolation(SOURCE, 3, 'int a')
+    }
+
     @Override
     protected ClassStartsWithBlankLineRule createRule() {
         new ClassStartsWithBlankLineRule()


### PR DESCRIPTION
The rule should now be able to handle annotations that contain a closure. 

I ran into this problem when using the Spock Requires annotations which takes a closure. I have tried to think of all the possible ways to combine annotations and such and implement test cases for them. 
