### PR TITLE
Ignore inner enums for GrailsDomain(HasEquals|ToString)

### DIFF
--- a/src/main/groovy/org/codenarc/rule/grails/GrailsDomainHasEqualsRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/grails/GrailsDomainHasEqualsRule.groovy
@@ -39,10 +39,14 @@ class GrailsDomainHasEqualsRule extends AbstractAstVisitorRule {
 class GrailsDomainHasEqualsAstVisitor extends AbstractAstVisitor {
     @Override
     void visitClassComplete(ClassNode classNode) {
-        if (isFirstVisit(classNode) && !hasAnnotation(classNode, 'EqualsAndHashCode') && !hasAnnotation(classNode, 'Canonical')) {
+        if (isFirstVisit(classNode) && !hasAnnotation(classNode, 'EqualsAndHashCode') && !hasAnnotation(classNode, 'Canonical') && isNotInnerEnum(classNode)) {
             if (!classNode.methods.any { isMethodNode(it, 'equals', 1) }) {
                 addViolation(classNode, "The domain class $classNode.name should define an equals(Object) method")
             }
         }
+    }
+
+    private boolean isNotInnerEnum(ClassNode classNode) {
+        !(classNode.outerClass != null && classNode.superClass.clazz.is(Enum))
     }
 }

--- a/src/main/groovy/org/codenarc/rule/grails/GrailsDomainHasToStringRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/grails/GrailsDomainHasToStringRule.groovy
@@ -40,10 +40,14 @@ class GrailsDomainHasToStringAstVisitor extends AbstractAstVisitor {
 
     @Override
     void visitClassComplete(ClassNode classNode) {
-        if (isFirstVisit(classNode) && !hasAnnotation(classNode, 'ToString') && !hasAnnotation(classNode, 'Canonical')) {
+        if (isFirstVisit(classNode) && !hasAnnotation(classNode, 'ToString') && !hasAnnotation(classNode, 'Canonical') && isNotInnerEnum(classNode)) {
             if (!classNode.methods.any { isMethodNode(it, 'toString', 0) }) {
                 addViolation(classNode, "The domain class $classNode.name should define a toString() method")
             }
         }
+    }
+
+    private boolean isNotInnerEnum(ClassNode classNode) {
+        !(classNode.outerClass != null && classNode.superClass.clazz.is(Enum))
     }
 }

--- a/src/test/groovy/org/codenarc/rule/grails/GrailsDomainHasEqualsRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/grails/GrailsDomainHasEqualsRuleTest.groovy
@@ -77,6 +77,24 @@ class GrailsDomainHasEqualsRuleTest extends AbstractRuleTestCase<GrailsDomainHas
         assertNoViolations(SOURCE)
     }
 
+    @Test
+    void testNoViolationOnInnerEnums() {
+        final SOURCE = '''
+            @EqualsAndHashCode
+            class Person {
+                Gender gender
+
+                enum Gender {
+                    MALE,
+                    FEMALE
+                }
+            }
+        '''
+
+        sourceCodePath = 'project/MyProject/grails-app/domain/com/xxx/Person.groovy'
+        assertNoViolations(SOURCE)
+    }
+
     @Override
     protected GrailsDomainHasEqualsRule createRule() {
         new GrailsDomainHasEqualsRule()

--- a/src/test/groovy/org/codenarc/rule/grails/GrailsDomainHasToStringRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/grails/GrailsDomainHasToStringRuleTest.groovy
@@ -77,6 +77,24 @@ class GrailsDomainHasToStringRuleTest extends AbstractRuleTestCase<GrailsDomainH
         assertNoViolations(SOURCE)
     }
 
+    @Test
+    void testNoViolationOnInnerEnums() {
+        final SOURCE = '''
+            @ToString
+            class Person {
+                Gender gender
+
+                enum Gender {
+                    MALE,
+                    FEMALE
+                }
+            }
+        '''
+
+        sourceCodePath = 'project/MyProject/grails-app/domain/com/xxx/Person.groovy'
+        assertNoViolations(SOURCE)
+    }
+
     @Override
     protected GrailsDomainHasToStringRule createRule() {
         new GrailsDomainHasToStringRule()


### PR DESCRIPTION
There's no apparent reason to expect enums to have an equal or toString.
In the case of "advanced" enums with fields, an enum is still an
immutable object and as such it's not necessary with a toString.