### PR TITLE
MethodReturnTypeRequiredRule now has an ignoredMethods property

### DIFF
--- a/src/main/groovy/org/codenarc/rule/convention/MethodReturnTypeRequiredRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/convention/MethodReturnTypeRequiredRule.groovy
@@ -18,9 +18,11 @@ package org.codenarc.rule.convention
 import org.codehaus.groovy.ast.MethodNode
 import org.codenarc.rule.AbstractAstVisitorRule
 import org.codenarc.rule.AbstractAstVisitor
+import org.codenarc.rule.AstVisitor
 
 /**
- * Checks that method return types are not dynamic, that is they are explicitly stated and different than def.
+ * Checks that method return types are not dynamic, that they are explicitly stated and different than def.
+ * The <code>ignoreMethods</code> property optionally specifices which methode names to ignore. Format is a comma separated list.
  *
  * @author Marcin Erdmann
  */
@@ -28,15 +30,26 @@ class MethodReturnTypeRequiredRule extends AbstractAstVisitorRule {
 
     String name = 'MethodReturnTypeRequired'
     int priority = 3
-    Class astVisitorClass = MethodReturnTypeRequiredAstVisitor
+    String ignoredMethods = ''
 
+    @Override
+    AstVisitor getAstVisitor() {
+        Set<String> parsedIgnoredMethods = ignoredMethods.tokenize(',').toSet()
+        return new MethodReturnTypeRequiredAstVisitor(parsedIgnoredMethods)
+    }
 }
 
 class MethodReturnTypeRequiredAstVisitor extends AbstractAstVisitor {
 
+    Set<String> ignoredMethods
+
+    MethodReturnTypeRequiredAstVisitor(Set<String> ignoredMethods) {
+        this.ignoredMethods = ignoredMethods
+    }
+
     @Override
     protected void visitMethodEx(MethodNode node) {
-        if (node.dynamicReturnType) {
+        if (node.dynamicReturnType && !ignoredMethods.contains(node.name)) {
             addViolation(node, $/Method "$node.name" has a dynamic return type/$)
         }
     }

--- a/src/main/groovy/org/codenarc/rule/convention/MethodReturnTypeRequiredRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/convention/MethodReturnTypeRequiredRule.groovy
@@ -16,10 +16,9 @@
 package org.codenarc.rule.convention
 
 import org.codehaus.groovy.ast.MethodNode
-import org.codenarc.rule.AbstractAstVisitorRule
 import org.codenarc.rule.AbstractAstVisitor
-import org.codenarc.rule.AstVisitor
-
+import org.codenarc.rule.AbstractAstVisitorRule
+import org.codenarc.util.WildcardPattern
 /**
  * Checks that method return types are not dynamic, that they are explicitly stated and different than def.
  * The <code>ignoreMethods</code> property optionally specifices which methode names to ignore. Format is a comma separated list.
@@ -30,28 +29,20 @@ class MethodReturnTypeRequiredRule extends AbstractAstVisitorRule {
 
     String name = 'MethodReturnTypeRequired'
     int priority = 3
-    String ignoredMethods = ''
-
-    @Override
-    AstVisitor getAstVisitor() {
-        Set<String> parsedIgnoredMethods = ignoredMethods.tokenize(',').toSet()
-        return new MethodReturnTypeRequiredAstVisitor(parsedIgnoredMethods)
-    }
+    Class astVisitorClass = MethodReturnTypeRequiredAstVisitor
+    String ignoreMethodNames = ''
 }
 
 class MethodReturnTypeRequiredAstVisitor extends AbstractAstVisitor {
 
-    Set<String> ignoredMethods
-
-    MethodReturnTypeRequiredAstVisitor(Set<String> ignoredMethods) {
-        this.ignoredMethods = ignoredMethods
-    }
-
     @Override
     protected void visitMethodEx(MethodNode node) {
-        if (node.dynamicReturnType && !ignoredMethods.contains(node.name)) {
+        if (node.dynamicReturnType && isNotIgnoredMethodName(node)) {
             addViolation(node, $/Method "$node.name" has a dynamic return type/$)
         }
     }
 
+    private boolean isNotIgnoredMethodName(MethodNode node) {
+        !(new WildcardPattern(rule.ignoreMethodNames, false).matches(node.name))
+    }
 }

--- a/src/test/groovy/org/codenarc/rule/convention/MethodReturnTypeRequiredRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/MethodReturnTypeRequiredRuleTest.groovy
@@ -79,6 +79,33 @@ class MethodReturnTypeRequiredRuleTest extends AbstractRuleTestCase<MethodReturn
         )
     }
 
+    @Test
+    void testNoViolationsWhenMethodIgnored() {
+        rule.ignoredMethods = 'beforeUpdate'
+
+        assertNoViolations '''
+            class ValidClass {
+                def beforeUpdate() {
+                }
+            }
+        '''
+    }
+
+    @Test
+    void testNoViolationsWhenMultipleMethodsIgnored() {
+        rule.ignoredMethods = 'beforeUpdate, beforeInsert'
+
+        assertNoViolations '''
+            class ValidClass {
+                def beforeUpdate() {
+                }
+
+                Object beforeInsert() {
+                }
+            }
+        '''
+    }
+
     @Override
     protected MethodReturnTypeRequiredRule createRule() {
         new MethodReturnTypeRequiredRule()

--- a/src/test/groovy/org/codenarc/rule/convention/MethodReturnTypeRequiredRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/MethodReturnTypeRequiredRuleTest.groovy
@@ -81,7 +81,7 @@ class MethodReturnTypeRequiredRuleTest extends AbstractRuleTestCase<MethodReturn
 
     @Test
     void testNoViolationsWhenMethodIgnored() {
-        rule.ignoredMethods = 'beforeUpdate'
+        rule.ignoreMethodNames = 'beforeUpdate'
 
         assertNoViolations '''
             class ValidClass {
@@ -93,7 +93,7 @@ class MethodReturnTypeRequiredRuleTest extends AbstractRuleTestCase<MethodReturn
 
     @Test
     void testNoViolationsWhenMultipleMethodsIgnored() {
-        rule.ignoredMethods = 'beforeUpdate, beforeInsert'
+        rule.ignoreMethodNames = 'beforeUpdate, beforeInsert'
 
         assertNoViolations '''
             class ValidClass {


### PR DESCRIPTION
http://gorm.grails.org/6.1.x/hibernate/manual/#eventsAutoTimestamping

Ran into a problem where these methods were being flagged. I would rather just that Codenarc ignore these methods.