### PR TITLE
MethodParameterTypeRequiredRule now has an ignoredParameters property

### DIFF
--- a/src/test/groovy/org/codenarc/rule/convention/MethodParameterTypeRequiredTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/MethodParameterTypeRequiredTest.groovy
@@ -36,6 +36,18 @@ class MethodParameterTypeRequiredTest extends AbstractRuleTestCase<MethodParamet
     }
 
     @Test
+    void testNoViolationsWithIgnoredParameter() {
+        rule.ignoredParameters = 'json'
+
+        assertNoViolations '''
+            class ValidClass {
+                void aMethod(def json) {
+                }
+            }
+        '''
+    }
+
+    @Test
     void testSingleViolation() {
         final SOURCE = '''
             class InvalidClass {

--- a/src/test/groovy/org/codenarc/rule/convention/MethodParameterTypeRequiredTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/MethodParameterTypeRequiredTest.groovy
@@ -37,7 +37,7 @@ class MethodParameterTypeRequiredTest extends AbstractRuleTestCase<MethodParamet
 
     @Test
     void testNoViolationsWithIgnoredParameter() {
-        rule.ignoredParameters = 'json'
+        rule.ignoreMethodParameterNames = 'json'
 
         assertNoViolations '''
             class ValidClass {


### PR DESCRIPTION
When working with parsed json in Groovy, we use "def json". It would be nice to add this as an ignored parameter type.

JsonSlurpers parse methods and other json tools in Groovy generally use def as the type, with the interface/usage generally being the same between implementations. Having to use the specific implementation types would not be particularly helpful for our developers.