### PR TITLE
StatelessClassRule now ignores fields annotated with @Value

### DIFF
--- a/src/main/groovy/org/codenarc/rule/generic/StatelessClassRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/generic/StatelessClassRule.groovy
@@ -34,7 +34,7 @@ import org.codenarc.util.WildcardPattern
  * This rule also ignores all classes annotated with the <code>@Immutable</code> transformation.
  * See http://groovy.codehaus.org/Immutable+transformation.
  * <p/>
- * This rule also ignores fields annotated with the <code>@Inject</code> annotation.
+ * This rule also ignores fields annotated with the <code>@Inject</code> and <code>@Value</code> annotation.
  * <p/>
  * You can configure this rule to ignore certain fields either by name or by type. This can be
  * useful to ignore fields that hold references to (static) dependencies (such as DAOs or
@@ -93,6 +93,7 @@ class StatelessClassRule extends AbstractAstVisitorRule {
     protected boolean shouldIgnoreField(FieldNode fieldNode) {
         return hasAnnotation(fieldNode.owner, 'Immutable') ||
             hasAnnotation(fieldNode, 'Inject') ||
+            hasAnnotation(fieldNode, 'Value') ||
             fieldNode.isFinal() ||
             matchesIgnoreFieldNames(fieldNode) ||
             matchesIgnoreFieldTypes(fieldNode)

--- a/src/test/groovy/org/codenarc/rule/generic/StatelessClassRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/generic/StatelessClassRuleTest.groovy
@@ -80,6 +80,18 @@ class StatelessClassRuleTest extends AbstractRuleTestCase<StatelessClassRule> {
     }
 
     @Test
+    void testApplyTo_IgnoresFieldsWithValueAnnotation() {
+        final SOURCE = '''
+          class MyClass {
+            @Value('${org.codenarc.test}')
+            BigDecimal depositAmount
+          }
+        '''
+        rule.applyToClassNames = '*'
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
     void testApplyTo_FinalField() {
         final SOURCE = '''
           class MyClass {


### PR DESCRIPTION
https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/beans/factory/annotation/Value.html

Getting some violations for Value annotated fields, but they are dependency injection fields handled by Spring. 