### PR TITLE
Manage -version argument when calling via cmd/bash +groovylintrc.json

### DIFF
--- a/.groovylintrc.json
+++ b/.groovylintrc.json
@@ -1,0 +1,47 @@
+{
+    "extends": "recommended",
+    "rules": {
+        "CatchThrowable": {
+            "enabled": false
+        },
+        "CompileStatic": {
+            "enabled": false
+        },
+        "DuplicateNumberLiteral": {
+            "enabled": false
+        },
+        "DuplicateStringLiteral": {
+            "enabled": false
+        },
+        "FactoryMethodName": {
+            "enabled": false
+        },
+        "FieldTypeRequired": {
+            "enabled": false
+        },
+        "LineLength": {
+            "enabled": false
+        },
+        "MethodCount": {
+            "enabled": false
+        },
+        "NestedBlockDepth": {
+            "enabled": false
+        },
+        "NoDef": {
+            "enabled": false
+        },
+        "SpaceAroundMapEntryColon": {
+            "enabled": false
+        },
+        "SystemExit": {
+            "enabled": false
+        },
+        "UnnecessaryGetter": {
+            "enabled": false
+        },
+        "VariableTypeRequired": {
+            "enabled": false
+        }
+    }
+}

--- a/src/main/groovy/org/codenarc/CodeNarc.groovy
+++ b/src/main/groovy/org/codenarc/CodeNarc.groovy
@@ -20,6 +20,7 @@ import org.codenarc.analyzer.SourceAnalyzer
 import org.codenarc.report.HtmlReportWriter
 import org.codenarc.report.ReportWriterFactory
 import org.codenarc.results.Results
+import org.codenarc.util.CodeNarcVersion
 
 /**
  * Command-line runner for CodeNarc.
@@ -126,15 +127,21 @@ Usage: java org.codenarc.CodeNarc [OPTIONS]
     static void main(String[] args) {
         def codeNarc = new CodeNarc()
 
+        // Show help
         if (args == ['-help'] as String[]) {
             println HELP
+            return
+        }
+        // Show version
+        else if (args == ['-version']) {
+            println CodeNarcVersion.getVersion()
             return
         }
 
         try {
             codeNarc.execute(args)
         }
-        catch(Throwable t) {
+        catch (Throwable t) {
             println "ERROR: ${t.toString()}"
             t.printStackTrace()
             println HELP
@@ -195,7 +202,7 @@ Usage: java org.codenarc.CodeNarc [OPTIONS]
             assert matcher, "Invalid argument format: [$arg]"
             def name = matcher[0][1]
             def value = matcher[0][2]
-            switch(name) {
+            switch (name) {
                 case 'rulesetfiles': ruleSetFiles = value; break
                 case 'basedir': baseDir = value; break
                 case 'includes': includes = value; break

--- a/src/main/groovy/org/codenarc/CodeNarc.groovy
+++ b/src/main/groovy/org/codenarc/CodeNarc.groovy
@@ -134,7 +134,8 @@ Usage: java org.codenarc.CodeNarc [OPTIONS]
         }
         // Show version
         else if (args == ['-version']) {
-            println CodeNarcVersion.getVersion()
+            def version = CodeNarcVersion.getVersion()
+            println "CodeNarc version $version"
             return
         }
 

--- a/src/test/groovy/org/codenarc/CodeNarcTest.groovy
+++ b/src/test/groovy/org/codenarc/CodeNarcTest.groovy
@@ -15,6 +15,9 @@
  */
 package org.codenarc
 
+import static org.codenarc.test.TestUtil.captureSystemOut
+import static org.codenarc.test.TestUtil.shouldFailWithMessageContaining
+
 import org.codenarc.analyzer.FilesystemSourceAnalyzer
 import org.codenarc.report.AbstractReportWriter
 import org.codenarc.report.HtmlReportWriter
@@ -22,12 +25,10 @@ import org.codenarc.report.ReportWriter
 import org.codenarc.report.XmlReportWriter
 import org.codenarc.results.Results
 import org.codenarc.test.AbstractTestCase
+import org.codenarc.util.CodeNarcVersion
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-
-import static org.codenarc.test.TestUtil.captureSystemOut
-import static org.codenarc.test.TestUtil.shouldFailWithMessageContaining
 
 /**
  * Tests for CodeNarc command-line runner
@@ -52,13 +53,13 @@ class CodeNarcTest extends AbstractTestCase {
     private File outputFile
     private int exitCode
 
-    private Map numViolations = [:].withDefault { 0 }
-    private Results results = [
-        getNumberOfViolationsWithPriority:{ priority, recursive ->
+    final private Map numViolations = [:].withDefault { 0 }
+    final private Results results = [
+        getNumberOfViolationsWithPriority: { priority, recursive ->
             assert recursive == true
             return numViolations[priority]
         }] as Results
-    private codeNarcRunner = [execute: { results }]
+    final private codeNarcRunner = [execute: { results }]
 
     //------------------------------------------------------------------------------------
     // Tests
@@ -318,6 +319,19 @@ class CodeNarcTest extends AbstractTestCase {
     }
 
     @Test
+    void testMain_Version() {
+        final ARGS = ['-version'] as String[]
+        def stdout = captureSystemOut {
+            CodeNarc.main(ARGS)
+        }
+        log("stdout=[$stdout]")
+        assert !stdout.contains('ERROR')
+        assert stdout.contains(CodeNarcVersion.getVersion())
+        assert !outputFile.exists()
+        assert exitCode == 0
+    }
+
+    @Test
     void testMain_BadOptionFormat() {
         final ARGS = ["-report=$HTML_REPORT_STR", '&^%#BAD%$#'] as String[]
         def stdout = captureSystemOut {
@@ -374,7 +388,9 @@ class CodeNarcTest extends AbstractTestCase {
 }
 
 class NoTitleReportWriter implements ReportWriter {
+
     @Override
     void writeReport(AnalysisContext analysisContext, Results results) {
     }
+
 }

--- a/src/test/groovy/org/codenarc/CodeNarcTest.groovy
+++ b/src/test/groovy/org/codenarc/CodeNarcTest.groovy
@@ -53,13 +53,13 @@ class CodeNarcTest extends AbstractTestCase {
     private File outputFile
     private int exitCode
 
-    final private Map numViolations = [:].withDefault { 0 }
-    final private Results results = [
+    private final Map numViolations = [:].withDefault { 0 }
+    private final Results results = [
         getNumberOfViolationsWithPriority: { priority, recursive ->
             assert recursive == true
             return numViolations[priority]
         }] as Results
-    final private codeNarcRunner = [execute: { results }]
+    private final codeNarcRunner = [execute: { results }]
 
     //------------------------------------------------------------------------------------
     // Tests
@@ -326,7 +326,9 @@ class CodeNarcTest extends AbstractTestCase {
         }
         log("stdout=[$stdout]")
         assert !stdout.contains('ERROR')
-        assert stdout.contains(CodeNarcVersion.getVersion())
+        def version = CodeNarcVersion.getVersion()
+        def expectedVersion = "CodeNarc version $version"
+        assert stdout.contains(expectedVersion), "$expectedVersion not found in $stdout"
         assert !outputFile.exists()
         assert exitCode == 0
     }


### PR DESCRIPTION
- Add -version argument management + test method
- Apply CodeNarc rules on updated files (using VsCode Groovy Lint)
- Added .groovylintrc.json so contributors using VsCode + VsCode Groovy Lint ignore the most restrictive violations

Note: locally there is a test failure on SourceFileTest when running gradlew check, as I updated nothing there, I have no idea where it can come from

Related to issue #477 