### PR TITLE
Rule to check for direct usages of GORM methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
+
 # CodeNarc Change Log
 
 TODO: Version 1.6    (?? 2020)
 --------------------------------------
 New Rules
 - #450: **ImplicitReturnStatement** rule (convention) - Checks for non-void methods that are missing an explicit return statement.
+- **GrailsDomainGormMethods** rule (grails) - Database operation should be performed by Data Services instead of calling GORM static and instance methods.
 
 Updated/Enhanced Rules and Bug Fixes
  - #451: **GetterMethodCouldBeProperty** rule: Fix handling of `ignoreMethodsWithOverrideAnnotation` property so it really only ignores @Override methods.

--- a/docs/codenarc-rules-grails.md
+++ b/docs/codenarc-rules-grails.md
@@ -5,6 +5,69 @@ title: CodeNarc - Grails Rules
 
 # Grails Rules  ("*rulesets/grails.xml*")
 
+## GrailsDomainGormMethods Rule
+
+<Since CodeNarc 1.6>
+
+Database operation should be performed by Data Services instead of calling GORM static and instance methods.
+
+Using the GORM static and instance methods may lead to spreading the persistence logic across the whole
+application instead of concentrating it into services. It makes difficult to find all the code working
+with the database in case of upgrades to the newer versions of Grails which require all persistence code
+running inside transactions.
+
+Data Services are available since Grails 3.3 and GORM 6.1.
+
+NOTE: This is a [CodeNarc Enhanced Classpath Rule](./codenarc-enhanced-classpath-rules.html).
+It requires **CodeNarc** to have the application classes being analyzed, as well as any referenced classes, on the classpath.
+
+Example of violations:
+
+```
+    class Person {
+        String firstName
+        String lastName
+    }
+
+    class PersonService {
+        
+        Person createPerson(String firstName, String lastName) {
+            Person person = new Person(firstName: firstName, lastName: lastName)
+            return person.save()
+        }
+    
+    }
+```
+
+Example of valid configuration:
+
+```
+    class Person {
+        String firstName
+        String lastName
+    }
+
+    @Service(Person)
+    class PersonDataService {
+        Person save(Person person)
+    }
+
+    class PersonService {
+
+        PersonDataService personDataService
+        
+        Person createPerson(String firstName, String lastName) {
+            Person person = new Person(firstName: firstName, lastName: lastName)
+            return personDataService.save(person)
+        }
+    
+    }
+```
+
+See [GORM Data Services](https://gorm.grails.org/latest/hibernate/manual/index.html#dataServices)
+
+See [Grails GORM Data Services Guide](https://guides.grails.org/grails-gorm-data-services/guide/index.html)
+
 
 ## GrailsDomainHasEquals Rule
 

--- a/src/main/groovy/org/codenarc/rule/grails/GrailsDomainGormMethodsRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/grails/GrailsDomainGormMethodsRule.groovy
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codenarc.rule.grails
+
+import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.ast.MethodNode
+import org.codehaus.groovy.ast.expr.ConstantExpression
+import org.codehaus.groovy.ast.expr.MethodCallExpression
+import org.codehaus.groovy.ast.expr.VariableExpression
+import org.codehaus.groovy.control.Phases
+import org.codenarc.rule.AbstractAstVisitor
+import org.codenarc.rule.AbstractAstVisitorRule
+
+/**
+ * Database operation should be performed by Data Services instead of calling GORM static and instance methods.
+ *
+ * @author Vladimir Orany
+ */
+class GrailsDomainGormMethodsRule extends AbstractAstVisitorRule {
+
+    public static final List<String> DEFAULT_GORM_STATIC_METHOD_NAMES = [
+            'attach',
+            'count',
+            'create',
+            'createCriteria',
+            'createQueryMapForExample',
+            'delete',
+            'deleteAll',
+            'discard',
+            'eachTenant',
+            'execute',
+            'executeQuery',
+            'executeUpdate',
+            'exists',
+            'finalize',
+            'find',
+            'findAll',
+            'findAllWhere',
+            'findOrCreateWhere',
+            'findOrSaveWhere',
+            'findWhere',
+            'first',
+            'get',
+            'getAll',
+            'ident',
+            'insert',
+            'instanceOf',
+            'isAttached',
+            'last',
+            'list',
+            'load',
+            'lock',
+            'merge',
+            'mutex',
+            'proxy',
+            'read',
+            'refresh',
+            'save',
+            'saveAll',
+            'unsupported',
+            'where',
+            'whereAny',
+            'whereLazy',
+            'withCriteria',
+            'withDatastoreSession',
+            'withNewSession',
+            'withNewTransaction',
+            'withSession',
+            'withStatelessSession',
+            'withTenant',
+            'withTransaction',
+    ].asImmutable()
+
+    String name = 'GrailsDomainGormMethods'
+    int priority = 3
+    Class astVisitorClass = GrailsDomainGormMethodsAstVisitor
+    int compilerPhase = Phases.SEMANTIC_ANALYSIS
+    List<String> gormStaticMethodsNamesList = DEFAULT_GORM_STATIC_METHOD_NAMES
+
+    String getGormStaticMethodsNames() {
+        return gormStaticMethodsNamesList.join(',')
+    }
+
+    void setGormStaticMethodsNames(String gormStaticMethodsNames) {
+        this.gormStaticMethodsNamesList = gormStaticMethodsNames.split(/\s*,\s*/).toList()
+    }
+
+}
+
+class GrailsDomainGormMethodsAstVisitor extends AbstractAstVisitor {
+
+    @Override
+    @SuppressWarnings('Instanceof')
+    void visitMethodCallExpression(MethodCallExpression call) {
+        if (call.method instanceof ConstantExpression) {
+            String methodName = call.method.value
+            ClassNode type = call.objectExpression.type
+            if (call.objectExpression instanceof VariableExpression && call.objectExpression.variable == 'this') {
+                type = currentClassNode
+            }
+            ClassNode gormEntityNode = type.interfaces.find {
+                it.name == 'org.grails.datastore.gorm.GormEntity'
+            }?.redirect()
+            if (gormEntityNode) {
+                List<MethodNode> methods = gormEntityNode.getMethods(methodName)
+                if (methods) {
+                    addViolation(call, "Prefer GORM Data Services to GORM instance calls like '$methodName'")
+                    return
+                }
+                if (rule.gormStaticMethodsNamesList.contains(methodName)) {
+                    addViolation(call, "Prefer GORM Data Services to GORM static calls like '$methodName'")
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/codenarc-base-messages.properties
+++ b/src/main/resources/codenarc-base-messages.properties
@@ -228,6 +228,9 @@ ConsecutiveBlankLines.description.html=Makes sure there are no consecutive lines
 MissingBlankLineAfterImports.description=Makes sure there is a blank line after the imports of a source code file.
 MissingBlankLineAfterImports.description.html=Makes sure there is a blank line after the imports of a source code file.
 
+GrailsDomainGormMethods.description=Database operation should be performed by Data Services instead of calling GORM static or instance methods.
+GrailsDomainGormMethods.description.html=Database operation should be performed by Data Services instead of calling GORM static or instance methods.
+
 GrailsDomainHasToString.description=Checks that Grails domain classes redefine toString()
 GrailsDomainHasToString.description.html=Checks that Grails domain classes redefine toString()
 

--- a/src/main/resources/rulesets/grails.xml
+++ b/src/main/resources/rulesets/grails.xml
@@ -8,6 +8,7 @@
         These rules implement standards and best practices related to the Grails framework (http://grails.org).
     </description>
 
+    <rule class='org.codenarc.rule.grails.GrailsDomainGormMethodsRule'/>
     <rule class='org.codenarc.rule.grails.GrailsDomainHasEqualsRule'/>
     <rule class='org.codenarc.rule.grails.GrailsDomainHasToStringRule'/>
     <rule class='org.codenarc.rule.grails.GrailsDuplicateMappingRule'/>

--- a/src/test/groovy/org/codenarc/rule/grails/GrailsDomainGormMethodsRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/grails/GrailsDomainGormMethodsRuleTest.groovy
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codenarc.rule.grails
+
+import org.junit.Test
+import org.codenarc.rule.AbstractRuleTestCase
+
+/**
+ * Tests for GrailsDomainGormMethodsRule
+ *
+ * @author Vladimir Orany
+ */
+class GrailsDomainGormMethodsRuleTest extends AbstractRuleTestCase<GrailsDomainGormMethodsRule> {
+
+    @Test
+    void test_RuleProperties() {
+        assert rule.priority == 3
+        assert rule.name == 'GrailsDomainGormMethods'
+    }
+
+    @Test
+    void test_SimilarMethodNamesButNotEntity_NoViolations() {
+        final String SOURCE = '''
+            class NoEntity {
+                NoEntity save() {
+
+                }
+
+                static List<NoEntity> list(){
+                    [new NoEntity()]
+                }
+
+            }
+
+            class SomeService {
+
+                void someMethod() {
+                    List<NoEntity> list = NoEntity.list()
+                    list.first().save()
+                }
+
+            }
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    @SuppressWarnings('DuplicateStringLiteral')
+    void test_GormMethodUsedOnEntity_Violations() {
+        final String SOURCE = '''
+            package org.grails.datastore.gorm
+
+            trait GormEntity<D> {
+                D save() {
+                    pritnln "saved $this"
+                }
+                static <D> List<D> list() {
+                    Collections.emptyList()
+                }
+            }
+
+            class SomeEntity implements GormEntity<SomeEntity> {
+
+                SomeEntity prepare() {
+                    save()
+                }
+
+            }
+
+            class SomeService {
+
+                void someMethod() {
+                    List<SomeEntity> entities = SomeEntity.list()
+                    SomeEntity firstEntity = list.first()
+                    firstEntity.save()
+                }
+
+            }
+        '''
+        assertViolations(SOURCE,
+            [
+                    lineNumber: 16,
+                    sourceLineText: 'save()',
+                    messageText: 'Prefer GORM Data Services to GORM instance calls like \'save\'',
+            ],
+            [
+                    lineNumber: 24,
+                    sourceLineText: 'List<SomeEntity> entities = SomeEntity.list()',
+                    messageText: 'Prefer GORM Data Services to GORM static calls like \'list\'',
+            ],
+            [
+                    lineNumber: 26,
+                    sourceLineText: 'firstEntity.save()',
+                    messageText: 'Prefer GORM Data Services to GORM instance calls like \'save\'',
+            ]
+        )
+    }
+
+    @Test
+    void test_CustomStaticMethodNames_Violations() {
+        rule.gormStaticMethodsNames = 'foo,bar,foobar'
+
+        final String SOURCE = '''
+            package org.grails.datastore.gorm
+
+            trait GormEntity<D> {
+                static <D> List<D> foobar() {
+                    Collections.emptyList()
+                }
+            }
+
+            class SomeEntity implements GormEntity<SomeEntity> { }
+
+            class SomeService {
+
+                void someMethod() {
+                    SomeEntity.foobar()
+                }
+
+            }
+        '''
+        assertViolations(SOURCE,
+                [
+                        lineNumber: 15,
+                        sourceLineText: 'SomeEntity.foobar()',
+                        messageText: 'Prefer GORM Data Services to GORM static calls like \'foobar\'',
+                ]
+        )
+    }
+
+    @Test
+    @SuppressWarnings([
+            'DuplicateMapLiteral',
+            'DuplicateNumberLiteral',
+            'DuplicateStringLiteral',
+    ])
+    void test_CustomStaticMethodNamesList_Violations() {
+        rule.gormStaticMethodsNamesList = ['foo', 'bar', 'foobar']
+
+        final String SOURCE = '''
+            package org.grails.datastore.gorm
+
+            trait GormEntity<D> {
+                static <D> List<D> foobar() {
+                    Collections.emptyList()
+                }
+            }
+
+            class SomeEntity implements GormEntity<SomeEntity> { }
+
+            class SomeService {
+
+                void someMethod() {
+                    SomeEntity.foobar()
+                }
+
+            }
+        '''
+        assertViolations(SOURCE,
+                [
+                        lineNumber: 15,
+                        sourceLineText: 'SomeEntity.foobar()',
+                        messageText: 'Prefer GORM Data Services to GORM static calls like \'foobar\'',
+                ]
+        )
+    }
+
+    @Override
+    protected GrailsDomainGormMethodsRule createRule() {
+        new GrailsDomainGormMethodsRule()
+    }
+
+}


### PR DESCRIPTION
It is very difficult to upgrade to newer versions of Grails when you have the persistence logic spread across the whole application. This rule checks for direct usages of GORM instance and static methods so it's easier to find them.

This is reworked #509 excluding the Gradle Wrapper update which I wasn't able to work around.