### PR TITLE
Fix #517: MissingBlankLineAfterImportsRule: add support for all import types

### DIFF
--- a/src/main/groovy/org/codenarc/rule/formatting/MissingBlankLineAfterImportsRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/MissingBlankLineAfterImportsRule.groovy
@@ -18,6 +18,7 @@ package org.codenarc.rule.formatting
 import org.codenarc.rule.AbstractRule
 import org.codenarc.rule.Violation
 import org.codenarc.source.SourceCode
+import org.codenarc.util.ImportUtil
 
 /**
  * Makes sure there is a blank line after the imports of a source code file.
@@ -29,8 +30,9 @@ class MissingBlankLineAfterImportsRule extends AbstractRule {
 
     @Override
     void applyTo(SourceCode sourceCode, List<Violation> violations) {
-        if (sourceCode.ast?.imports) {
-            int lastImportLineNumber = sourceCode.ast.imports*.lastLineNumber.max()
+        def imports = ImportUtil.getAllImports(sourceCode)
+        if (imports) {
+            int lastImportLineNumber = imports*.lastLineNumber.max()
 
             if (lastImportLineNumber > 0) {
                 String nextLine = sourceCode.line(lastImportLineNumber)

--- a/src/test/groovy/org/codenarc/rule/formatting/MissingBlankLineAfterImportsRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/MissingBlankLineAfterImportsRuleTest.groovy
@@ -23,6 +23,13 @@ import org.junit.Test
  */
 class MissingBlankLineAfterImportsRuleTest extends AbstractRuleTestCase<MissingBlankLineAfterImportsRule> {
 
+    private static final IMPORT_TYPES = [
+        'import java.lang.Math', // normal
+        'import java.lang.*', // star
+        'import static java.lang.Math.PI', // static
+        'import static java.lang.Math.*', // static star
+    ]
+
     @Test
     void test_RuleProperties() {
         assert rule.priority == 3
@@ -30,64 +37,70 @@ class MissingBlankLineAfterImportsRuleTest extends AbstractRuleTestCase<MissingB
     }
 
     @Test
-    void test_BlankLineAfterImports_NoViolation() {
-        final SOURCE = '''\
+    void test_BlankLineAfterLastImport_NoViolation() {
+        IMPORT_TYPES.each { lastImport ->
+            final SOURCE = """\
             package org.codenarc
 
             import org.codenarc.rule.Rule
-            import org.codenarc.rule.StubRule
+            $lastImport
 
-            class MyClass {
-                    def go() { /* ... */ }
-            }
-            '''.stripIndent()
-        assertNoViolations(SOURCE)
+            class MyClass { }
+            """.stripIndent()
+            assertNoViolations(SOURCE)
+        }
     }
 
-    @SuppressWarnings('MissingBlankLineAfterImports')
     @Test
-    void test_NoLinesAfterImports_Violation() {
-        final SOURCE = '''
+    void test_NoBlankLineAfterLastImport_Violation() {
+        IMPORT_TYPES.each { lastImport ->
+            final SOURCE = """\
             package org.codenarc
 
             import org.codenarc.rule.Rule
-            import org.codenarc.rule.StubRule
-            class MyClass {
-                    void go() { /* ... */ }
-            }'''.stripIndent()
-        assertSingleViolation(SOURCE, 6, 'class MyClass {', 'Missing blank line after imports in file null')
+            $lastImport
+            class MyClass { }
+            """.stripIndent()
+            assertSingleViolation(SOURCE, 5, 'class MyClass { }', 'Missing blank line after imports in file null')
+        }
     }
 
     @Test
-    void test_PackageInfo_NothingAfter_LastImport_NoViolation() {
-        final SOURCE = '''
-            package com.a.random.pkg.nothing.to.see.here
+    void test_PackageInfo_NothingAfterLastImport_NoViolation() {
+        IMPORT_TYPES.each { lastImport ->
+            final SOURCE = """\
+                package org.codenarc
 
-            import com.very.very.important.pkg
-        '''.stripIndent()
-        assertNoViolations(SOURCE)
+                $lastImport
+                """.stripIndent()
+            assertNoViolations(SOURCE)
+        }
     }
 
     @Test
-    void test_PackageInfo_NotABlankLineAfterLastImport_NoViolation() {
-        final SOURCE = '''
-            package com.a.random.pkg.nothing.to.see.here
+    void test_PackageInfo_BlankLineAfterLastImport_NoViolation() {
+        IMPORT_TYPES.each { lastImport ->
+            final SOURCE = """\
+                package org.codenarc
 
-            import com.very.very.important.pkg
-            // comment
-        '''.stripIndent()
-        assertSingleViolation(SOURCE, 5, '// comment', 'Missing blank line after imports')
+                $lastImport
+
+                """.stripIndent()
+            assertNoViolations(SOURCE)
+        }
     }
 
     @Test
-    void test_PackageInfo_NoViolation() {
-        final SOURCE = '''
-            package com.a.random.pkg.nothing.to.see.here
+    void test_PackageInfo_NoBlankLineAfterLastImport_Violation() {
+        IMPORT_TYPES.each { lastImport ->
+            final SOURCE = """\
+                package org.codenarc
 
-            import com.very.very.important.pkg
-
-        '''.stripIndent()
-        assertNoViolations(SOURCE)
+                $lastImport
+                // comment
+                """.stripIndent()
+            assertSingleViolation(SOURCE, 4, '// comment', 'Missing blank line after imports')
+        }
     }
 
     @Override


### PR DESCRIPTION
The implementation formerly only considered normal imports.

Clean up tests & make them more consistent too.