### PR TITLE
Update publishing mechanism

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'groovy'
-    id 'maven'
+    id 'maven-publish'
     id 'signing'
     id 'idea'
 }
@@ -51,24 +51,9 @@ sourceSets {
 test.maxParallelForks = 2
 test.jvmArgs '-Duser.language=en -Duser.country=US'
 
-task javadocJar(type: Jar) {
-    classifier = 'javadoc'
-    from javadoc
-}
-
-task sourcesJar(type: Jar) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
-
-artifacts {
-    archives javadocJar, sourcesJar
-}
-
-signing {
-    sign(configurations.archives).each { task ->
-        task.onlyIf { gradle.taskGraph.hasTask(uploadArchives) }
-    }
+java {
+    withJavadocJar()
+    withSourcesJar()
 }
 
 javadoc {
@@ -77,48 +62,55 @@ javadoc {
     }
 }
 
+signing {
+    required { gradle.taskGraph.hasTask(publish) }
+    sign publishing.publications
+}
+
 // Publish to Sonatype (OSSRH) Maven Repository
 // See http://central.sonatype.org/pages/gradle.html
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            beforeDeployment { deployment -> signing.signPom(deployment) }
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
 
-            repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
-            }
-
-            snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots/') {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
-            }
-
-            pom.project {
-                name 'CodeNarc'
-                packaging 'jar'
-                // optionally artifactId can be defined here
-                description 'The CodeNarc project provides a static analysis tool for Groovy code.'
-                url 'https://codenarc.org'
+            pom {
+                name = 'CodeNarc'
+                description = 'The CodeNarc project provides a static analysis tool for Groovy code.'
+                url = 'https://codenarc.org'
 
                 scm {
-                    connection 'scm:git:git@github.com:CodeNarc/CodeNarc.git'
-                    developerConnection 'scm:git:git@github.com:CodeNarc/CodeNarc.git'
-                    url 'scm:git:git@github.com:CodeNarc/CodeNarc.git'
+                    connection = 'scm:git:git@github.com:CodeNarc/CodeNarc.git'
+                    developerConnection = 'scm:git:git@github.com:CodeNarc/CodeNarc.git'
+                    url = 'scm:git:git@github.com:CodeNarc/CodeNarc.git'
                 }
 
                 licenses {
                     license {
-                        name 'The Apache License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
                     }
                 }
 
                 developers {
                     developer {
-                        id 'chrismair'
-                        name 'Chris Mair'
-                        email 'chrismair@users.sourceforge.net'
+                        id = 'chrismair'
+                        name = 'Chris Mair'
+                        email = 'chrismair@users.sourceforge.net'
                     }
                 }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            def releasesUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+            def snapshotsUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+            url = project.hasProperty('release') ? releasesUrl : snapshotsUrl
+            credentials {
+                username = ossrhUsername
+                password = ossrhPassword
             }
         }
     }


### PR DESCRIPTION
This one is up for discussion. I suggest that you try it locally before merging. Because I don't know the details of the current release process, I introduced the "release" project property (according to some Gradle documentation) to decide whether to publish to the "release" or the "snapshot" repository.

The following text is from the commit comment:

The "maven" plugin is deprecated. The "maven-publish" plugin should be used.

Gradle module metadata is now published too.

The following tasks are now relevant for publishing:
- publishToMavenLocal - Publishes all Maven publications produced by this project to the local Maven cache.
- publish - Publishes all publications produced by this project.

If the project property "release" is present, publishing is using the "release" instead of the "snapshot" repository (`./gradlew -Prelease publish`).

References
- https://docs.gradle.org/6.5/userguide/upgrading_version_5.html#changes_6.0
- https://docs.gradle.org/6.5/userguide/publishing_setup.html
- https://docs.gradle.org/6.5/userguide/publishing_maven.html
- https://docs.gradle.org/6.5/userguide/java_plugin.html
- https://docs.gradle.org/6.5/userguide/signing_plugin.html
- https://blog.gradle.org/gradle-metadata-1.0