### PR TITLE
Do not assume that expression's column number will always be set in SpaceAfterCommaRule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     testImplementation 'commons-cli:commons-cli:1.4'
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.github.stefanbirkner:system-rules:1.16.1'
+
+    testRuntime "org.codehaus.groovy:groovy-macro:$groovyVersion"
 }
 
 sourceSets {

--- a/src/main/groovy/org/codenarc/rule/formatting/SpaceAfterCommaRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/SpaceAfterCommaRule.groovy
@@ -95,7 +95,7 @@ class SpaceAfterCommaAstVisitor extends AbstractAstVisitor {
             def parameterExpressions = arguments.expressions
 
             parameterExpressions.each { e ->
-                if (!isClosureParameterOutsideParentheses(e, arguments)) {
+                if (!isClosureParameterOutsideParentheses(e, arguments) && e.columnNumber > 1) {
                     String line = sourceLine(e)
                     String previousChar = line[e.columnNumber - 2]
 

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterCommaRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterCommaRuleTest.groovy
@@ -66,6 +66,18 @@ class SpaceAfterCommaRuleTest extends AbstractRuleTestCase<SpaceAfterCommaRule> 
     }
 
     @Test
+    void testApplyTo_Macro() {
+        final SOURCE = '''
+            class ClassUsingMacros {
+                Statement statementCreatedUsingMacros() {
+                    def code = macro { return toString() } as Statement
+                }
+            }
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
     void testApplyTo_MethodCall_NoPrecedingSpaceForSingleParameter_Violation() {
         final SOURCE = '''
             class MyTestCase {


### PR DESCRIPTION
This is not the case when using macros.

Fixes #566