### PR TITLE
Create a Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,44 @@
-FROM openjdk:8-jdk-slim AS build
+ARG CODENARC_VERSION=2.0.0
+ARG JAVA_VERSION=8
+ARG GROOVY_VERSION=2.5.12
+ARG SLF4J_VERSION=1.7.25
+ARG GMETRICS_VERSION=1.1
 
-WORKDIR /code
+FROM buildpack-deps:stable-curl AS downloads
 
-COPY . /code
+ARG GROOVY_VERSION
+ARG CODENARC_VERSION
+ARG SLF4J_VERSION
+ARG GMETRICS_VERSION
 
-RUN ./gradlew --quiet --no-daemon shadowJar
+RUN mkdir -p /downloads && cd /downloads \
+ && curl -fsSLO https://search.maven.org/remotecontent?filepath=org/codenarc/CodeNarc/$CODENARC_VERSION/CodeNarc-$CODENARC_VERSION.jar \
+ && curl -fsSLO https://search.maven.org/remotecontent?filepath=org/codehaus/groovy/groovy/$GROOVY_VERSION/groovy-$GROOVY_VERSION.jar \
+ && curl -fsSLO https://search.maven.org/remotecontent?filepath=org/codehaus/groovy/groovy-xml/$GROOVY_VERSION/groovy-xml-$GROOVY_VERSION.jar \
+ && curl -fsSLO https://search.maven.org/remotecontent?filepath=org/codehaus/groovy/groovy-json/$GROOVY_VERSION/groovy-json-$GROOVY_VERSION.jar \
+ && curl -fsSLO https://search.maven.org/remotecontent?filepath=org/codehaus/groovy/groovy-ant/$GROOVY_VERSION/groovy-ant-$GROOVY_VERSION.jar \
+ && curl -fsSLO https://search.maven.org/remotecontent?filepath=org/codehaus/groovy/groovy-templates/$GROOVY_VERSION/groovy-templates-$GROOVY_VERSION.jar \
+ && curl -fsSLO https://search.maven.org/remotecontent?filepath=org/slf4j/slf4j-api/$SLF4J_VERSION/slf4j-api-$SLF4J_VERSION.jar \
+ && curl -fsSLO https://search.maven.org/remotecontent?filepath=org/slf4j/slf4j-simple/$SLF4J_VERSION/slf4j-simple-$SLF4J_VERSION.jar \
+ && curl -fsSLO https://search.maven.org/remotecontent?filepath=org/gmetrics/GMetrics/$GMETRICS_VERSION/GMetrics-$GMETRICS_VERSION.jar
 
-RUN echo '#!/bin/bash' > codenarc \
- && echo '/usr/local/openjdk-8/bin/java -jar /opt/codenarc.jar "$@"' >> codenarc \
- && chmod 755 codenarc
+FROM openjdk:$JAVA_VERSION
 
-FROM openjdk:8-jre-slim
+ARG GROOVY_VERSION
+ARG CODENARC_VERSION
+ARG SLF4J_VERSION
+ARG GMETRICS_VERSION
 
-COPY --from=build /code/build/libs/CodeNarc-*-all.jar /opt/codenarc.jar
-COPY --from=build /code/codenarc /usr/local/bin/codenarc
+ENV GROOVY_VERSION=$GROOVY_VERSION
+ENV CODENARC_VERSION=$CODENARC_VERSION
+ENV SLF4J_VERSION=$SLF4J_VERSION
+ENV GMETRICS_VERSION=$GMETRICS_VERSION
+
+COPY --from=downloads /downloads/*.jar /opt/
+
+RUN echo '#!/bin/bash' > /usr/local/bin/codenarc \
+ && echo "$JAVA_HOME/bin/java -cp '/opt/CodeNarc-$CODENARC_VERSION.jar:/opt/groovy-$GROOVY_VERSION.jar:/opt/groovy-xml-$GROOVY_VERSION.jar:/opt/groovy-json-$GROOVY_VERSION.jar:/opt/groovy-ant-$GROOVY_VERSION.jar:/opt/groovy-templates-$GROOVY_VERSION.jar:/opt/slf4j-api-$SLF4J_VERSION.jar:/opt/slf4j-simple-$SLF4J_VERSION.jar:/opt/GMetrics-$GMETRICS_VERSION.jar'"' org.codenarc.CodeNarc "$@"' >> /usr/local/bin/codenarc \
+ && chmod 755 /usr/local/bin/codenarc
 
 WORKDIR /code
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM openjdk:8-jdk-slim AS build
+
+WORKDIR /code
+
+COPY . /code
+
+RUN ./gradlew --quiet --no-daemon shadowJar
+
+RUN echo '#!/bin/bash' > codenarc \
+ && echo '/usr/local/openjdk-8/bin/java -jar /opt/codenarc.jar "$@"' >> codenarc \
+ && chmod 755 codenarc
+
+FROM openjdk:8-jre-slim
+
+COPY --from=build /code/build/libs/CodeNarc-*-all.jar /opt/codenarc.jar
+COPY --from=build /code/codenarc /usr/local/bin/codenarc
+
+WORKDIR /code
+
+CMD /usr/local/bin/codenarc

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+VERSION=$(docker run --rm "$IMAGE_NAME" codenarc -version | sed 's/^CodeNarc version //')
+
+docker tag "$IMAGE_NAME" "$DOCKER_REPO:$VERSION"
+docker push "$DOCKER_REPO:$VERSION"


### PR DESCRIPTION
* add fatJar task to Gradle build
* add Dockerfile
* customize Docker Hub build

An image is already available on Docker Hub as [`ericcitaire/codenarc`](https://hub.docker.com/repository/docker/ericcitaire/codenarc).

Example usage :
```
docker run --rm -v $(pwd):/code ericcitaire/codenarc:2.0.0 codenarc -report=text:stdout
```

This can be really useful in CI builds for example.

Cheers,
Eric.