### PR TITLE
Adding the Inline Console Report Writer to facilitate the read using format strings like errorformat

### DIFF
--- a/src/main/groovy/org/codenarc/report/InlineConsoleReportWriter.groovy
+++ b/src/main/groovy/org/codenarc/report/InlineConsoleReportWriter.groovy
@@ -18,7 +18,6 @@ package org.codenarc.report
 import org.codenarc.AnalysisContext
 import org.codenarc.results.FileResults
 import org.codenarc.results.Results
-import org.codenarc.rule.Violation
 
 /**
  * ReportWriter that generates an simple inline ASCII text report.

--- a/src/main/groovy/org/codenarc/report/InlineConsoleReportWriter.groovy
+++ b/src/main/groovy/org/codenarc/report/InlineConsoleReportWriter.groovy
@@ -30,7 +30,7 @@ import org.codenarc.rule.Violation
  *
  * @author Luis Zimmermann
  */
-class InlineTextReportWriter extends AbstractReportWriter {
+class InlineConsoleReportWriter extends AbstractReportWriter {
 
     String title
     String defaultOutputFile = 'CodeNarcInlineReport.txt'

--- a/src/main/groovy/org/codenarc/report/InlineConsoleReportWriter.groovy
+++ b/src/main/groovy/org/codenarc/report/InlineConsoleReportWriter.groovy
@@ -31,8 +31,6 @@ import org.codenarc.results.Results
  */
 class InlineConsoleReportWriter extends AbstractReportWriter {
 
-    String title
-    String defaultOutputFile = 'CodeNarcInlineReport.txt'
     int maxPriority = 3
 
     @Override

--- a/src/main/groovy/org/codenarc/report/InlineTextReportWriter.groovy
+++ b/src/main/groovy/org/codenarc/report/InlineTextReportWriter.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codenarc.report
+
+import org.codenarc.AnalysisContext
+import org.codenarc.results.FileResults
+import org.codenarc.results.Results
+import org.codenarc.rule.Violation
+
+/**
+ * ReportWriter that generates an simple inline ASCII text report.
+ *
+ * Set the maxPriority property to control the maximum priority level for violations in
+ * the report. For instance, setting maxPriority to 2 will result in the report containing
+ * only priority 1 and 2 violations (and omitting violations with priority 3). The
+ * maxPriority property defaults to 3.
+ *
+ * @author Luis Zimmermann
+ */
+class InlineTextReportWriter extends AbstractReportWriter {
+
+    String title
+    String defaultOutputFile = 'CodeNarcInlineReport.txt'
+    int maxPriority = 3
+
+    @Override
+    void writeReport(Writer writer, AnalysisContext analysisContext, Results results) {
+        initializeResourceBundle()
+        def printWriter = new PrintWriter(writer)
+        writePackageViolations(printWriter, results)
+        printWriter.flush()
+    }
+
+    protected void writePackageViolations(Writer writer, Results results) {
+        results.children.each { child ->
+            if (child.isFile()) {
+                writeFileViolations(writer, child)
+            }
+            else {
+                writePackageViolations(writer, child)
+            }
+        }
+    }
+
+    protected void writeFileViolations(Writer writer, FileResults results) {
+        if (results.violations.find { v -> v.rule.priority <= maxPriority }) {
+            String file = results.path
+            def violations = results.violations.findAll { v -> v.rule.priority <= maxPriority }
+            violations.sort { violation -> violation.rule.priority }.each { violation ->
+                writer.println "${file}:${violation.lineNumber}:${violation.rule.name} ${violation.message}"
+            }
+        }
+    }
+}

--- a/src/main/groovy/org/codenarc/report/ReportWriterFactory.groovy
+++ b/src/main/groovy/org/codenarc/report/ReportWriterFactory.groovy
@@ -41,6 +41,7 @@ class ReportWriterFactory {
             case 'ide': def w = new IdeTextReportWriter(); w.writeToStandardOut = true; return w
             case 'inlineXml' : return new InlineXmlReportWriter()
             case 'baseline': return new BaselineXmlReportWriter()
+            case 'inlineConsole': def w = new InlineTextReportWriter(); w.writeToStandardOut = true; return w
         }
 
         def reportClass = getClass().classLoader.loadClass(type)

--- a/src/main/groovy/org/codenarc/report/ReportWriterFactory.groovy
+++ b/src/main/groovy/org/codenarc/report/ReportWriterFactory.groovy
@@ -41,7 +41,7 @@ class ReportWriterFactory {
             case 'ide': def w = new IdeTextReportWriter(); w.writeToStandardOut = true; return w
             case 'inlineXml' : return new InlineXmlReportWriter()
             case 'baseline': return new BaselineXmlReportWriter()
-            case 'inlineConsole': def w = new InlineTextReportWriter(); w.writeToStandardOut = true; return w
+            case 'inlineConsole': def w = new InlineConsoleReportWriter(); w.writeToStandardOut = true; return w
         }
 
         def reportClass = getClass().classLoader.loadClass(type)

--- a/src/test/groovy/org/codenarc/report/AbstractInlineConsoleReportWriterTestCase.groovy
+++ b/src/test/groovy/org/codenarc/report/AbstractInlineConsoleReportWriterTestCase.groovy
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codenarc.report
+
+import org.codenarc.AnalysisContext
+import org.codenarc.results.DirectoryResults
+import org.codenarc.results.FileResults
+import org.codenarc.rule.StubRule
+import org.codenarc.rule.Violation
+import org.codenarc.test.AbstractTestCase
+import org.junit.Before
+import org.junit.Test
+
+import static org.codenarc.test.TestUtil.captureSystemOut
+import static org.codenarc.test.TestUtil.shouldFailWithMessageContaining
+import static org.junit.Assert.assertEquals
+
+/**
+ * Abstract superclass for TestReportWriter and subclass tests
+ *
+ * @author Luis Zimmermann
+ */
+abstract class AbstractInlineConsoleReportWriterTestCase extends AbstractTestCase {
+
+    protected static final int LINE1 = 11
+    protected static final int LINE2 = 2
+    protected static final int LINE3 = 333
+    protected static final String SOURCE_LINE1 = 'if (count < 23 && index <= 99) {'
+    protected static final String SOURCE_LINE3 = 'throw new Exception() // Something bad happened'
+    protected static final String MESSAGE2 = 'bad stuff: !@#$%^&*()_+<>'
+    protected static final String MESSAGE3 = 'Other info'
+    protected static final Violation VIOLATION1 = new Violation(rule:new StubRule(name:'Rule1', priority:1), lineNumber:LINE1, sourceLine:SOURCE_LINE1)
+    protected static final Violation VIOLATION2 = new Violation(rule:new StubRule(name:'AnotherRule', priority:2), lineNumber:LINE2, message:MESSAGE2)
+    protected static final Violation VIOLATION3 = new Violation(rule:new StubRule(name:'BadStuff', priority:3), lineNumber:LINE3, sourceLine:SOURCE_LINE3, message:MESSAGE3 )
+    protected static final String SRC_DIR1 = 'c:/MyProject/src/main/groovy'
+    protected static final String SRC_DIR2 = 'c:/MyProject/src/test/groovy'
+    protected static final String VERSION_FILE = 'src/main/resources/codenarc-version.txt'
+    protected static final String VERSION = new File(VERSION_FILE).text
+    protected static final String CODENARC_URL = 'https://www.codenarc.org'
+
+    protected reportWriter
+    protected analysisContext
+    protected results, srcMainDaoDirResults
+    protected stringWriter
+
+    //------------------------------------------------------------------------------------
+    // Abstract declarations
+    //------------------------------------------------------------------------------------
+
+    protected abstract InlineConsoleReportWriter createReportWriter()
+    protected abstract String getReportText()
+
+    //------------------------------------------------------------------------------------
+    // Tests
+    //------------------------------------------------------------------------------------
+
+    @Test
+    void testWriteReport_WritesToStandardOut() {
+        reportWriter.writeToStandardOut = true
+        def output = captureSystemOut {
+            reportWriter.writeReport(analysisContext, results)
+        }
+        assertReportText(output, getReportText())
+    }
+
+    @Test
+    void testWriteReport_NullResults() {
+        shouldFailWithMessageContaining('results') { reportWriter.writeReport(analysisContext, null) }
+    }
+
+    @Test
+    void testWriteReport_NullAnalysisContext() {
+        shouldFailWithMessageContaining('analysisContext') { reportWriter.writeReport(null, results) }
+    }
+
+    @Test
+    void testMaxPriority_DefaultsTo3() {
+        assert reportWriter.maxPriority == 3
+    }
+
+    //------------------------------------------------------------------------------------
+    // Setup and helper methods
+    //------------------------------------------------------------------------------------
+
+    @Before
+    void setUpAbstractInlineConsoleReportWriterTestCase() {
+        reportWriter = createReportWriter()
+        reportWriter.getTimestamp = { TIMESTAMP_DATE }
+
+        def srcMainDirResults = new DirectoryResults('src/main', 1)
+        srcMainDaoDirResults = new DirectoryResults('src/main/dao', 2)
+        def srcTestDirResults = new DirectoryResults('src/test', 3)
+        def srcMainFileResults1 = new FileResults('src/main/MyAction.groovy', [VIOLATION1, VIOLATION3, VIOLATION3, VIOLATION1, VIOLATION2])
+        def fileResultsMainDao1 = new FileResults('src/main/dao/MyDao.groovy', [VIOLATION3])
+        def fileResultsMainDao2 = new FileResults('src/main/dao/MyOtherDao.groovy', [VIOLATION2, VIOLATION1])
+
+        srcMainDirResults.addChild(srcMainFileResults1)
+        srcMainDirResults.addChild(srcMainDaoDirResults)
+        srcMainDaoDirResults.addChild(fileResultsMainDao1)
+        srcMainDaoDirResults.addChild(fileResultsMainDao2)
+
+        results = new DirectoryResults()
+        results.addChild(srcMainDirResults)
+        results.addChild(srcTestDirResults)
+
+        analysisContext = new AnalysisContext(sourceDirectories:[SRC_DIR1, SRC_DIR2])
+        stringWriter = new StringWriter()
+    }
+
+    @SuppressWarnings('JUnitStyleAssertions')
+    protected void assertReportText(String actualText, String expectedText) {
+        def actualLines = actualText.readLines()
+        def expectedLines = expectedText.readLines()
+        actualLines.eachWithIndex { line, index ->
+            def lineNumber = "$index".padLeft(2)
+            println "$lineNumber: $line"
+            assertEquals("line=$line", expectedLines[index], line)
+        }
+        assertEquals(expectedLines.size(), actualLines.size())
+    }
+
+    @SuppressWarnings('ConfusingMethodName')
+    protected static String version() {
+        return VERSION
+    }
+}

--- a/src/test/groovy/org/codenarc/report/InlineConsoleReportWriterTest.groovy
+++ b/src/test/groovy/org/codenarc/report/InlineConsoleReportWriterTest.groovy
@@ -18,8 +18,7 @@ package org.codenarc.report
 /**
  * Tests for TestReportWriter
  *
- * @author Chris Mair
- * @author Hamlet D'Arcy
+ * @author Luis Zimmermann
  */
 class InlineConsoleReportWriterTest extends AbstractInlineConsoleReportWriterTestCase {
 

--- a/src/test/groovy/org/codenarc/report/InlineConsoleReportWriterTest.groovy
+++ b/src/test/groovy/org/codenarc/report/InlineConsoleReportWriterTest.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codenarc.report
+
+/**
+ * Tests for TestReportWriter
+ *
+ * @author Chris Mair
+ * @author Hamlet D'Arcy
+ */
+class InlineConsoleReportWriterTest extends AbstractInlineConsoleReportWriterTestCase {
+
+    private static final REPORT_TEXT = """
+src/main/MyAction.groovy:11:Rule1 null
+src/main/MyAction.groovy:11:Rule1 null
+src/main/MyAction.groovy:2:AnotherRule bad stuff: !@#\$%^&*()_+<>
+src/main/MyAction.groovy:333:BadStuff Other info
+src/main/MyAction.groovy:333:BadStuff Other info
+src/main/dao/MyDao.groovy:333:BadStuff Other info
+src/main/dao/MyOtherDao.groovy:11:Rule1 null
+src/main/dao/MyOtherDao.groovy:2:AnotherRule bad stuff: !@#\$%^&*()_+<>
+""".trim()
+
+    @Override
+    protected InlineConsoleReportWriter createReportWriter() {
+        return new InlineConsoleReportWriter()
+    }
+
+    @Override
+    protected String getReportText() {
+        return REPORT_TEXT
+    }
+
+}

--- a/src/test/groovy/org/codenarc/report/ReportWriterFactoryTest.groovy
+++ b/src/test/groovy/org/codenarc/report/ReportWriterFactoryTest.groovy
@@ -60,6 +60,13 @@ class ReportWriterFactoryTest extends AbstractTestCase {
     }
 
     @Test
+    void testGetReportWriter_InlineConsole() {
+        def reportWriter = reportWriterFactory.getReportWriter('inlineConsole')
+        assert reportWriter.class == InlineConsoleReportWriter
+        assert reportWriter.writeToStandardOut
+    }
+
+    @Test
     void testGetReportWriter_Ide() {
         def reportWriter = reportWriterFactory.getReportWriter('ide')
         assert reportWriter.class == IdeTextReportWriter


### PR DESCRIPTION
With this simple format we can read the output easily with grok and other types of format strings.

Tests heavily inspired by TextReportWriter.