### PR TITLE
Dockerfile to build CodeNarc Docker image using Gradle and Shadowjar

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,10 @@
-FROM openjdk:8-jdk
+FROM openjdk:8-jre-slim AS gradle
 
 ARG CODENARC_VERSION=2.0.0
 ARG GROOVY_VERSION=2.5.12
 ARG GRADLE_VERSION=6.5.1
 
-RUN apt-get update && apt-get install -y unzip
+RUN apt-get update && apt-get install -y unzip curl
 WORKDIR /gradle
 RUN curl -L https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip -o gradle-$GRADLE_VERSION-bin.zip
 RUN unzip gradle-$GRADLE_VERSION-bin.zip
@@ -16,8 +16,14 @@ RUN sed -e "s/\${codenarc.version}/$CODENARC_VERSION/" -e "s/\${groovy.version}/
 
 RUN gradle --quiet --no-daemon shadowJar
 
+FROM openjdk:8-jre-slim
+
+WORKDIR /lib
+COPY --from=gradle /gradle/build/libs/codenarc-all.jar /lib/codenarc-all.jar
+RUN chmod 755 /lib/codenarc-all.jar
+
 WORKDIR /work
 COPY . /work
 
-ENTRYPOINT ["java", "-jar", "/gradle/build/libs/codenarc-all.jar"]
+ENTRYPOINT ["java", "-jar", "/lib/codenarc-all.jar"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM openjdk:8-jdk
+
+ARG CODENARC_VERSION=2.0.0
+ARG GROOVY_VERSION=2.5.12
+ARG GRADLE_VERSION=6.5.1
+
+RUN apt-get update && apt-get install -y unzip
+WORKDIR /gradle
+RUN curl -L https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip -o gradle-$GRADLE_VERSION-bin.zip
+RUN unzip gradle-$GRADLE_VERSION-bin.zip
+ENV GRADLE_HOME=/gradle/gradle-$GRADLE_VERSION
+ENV PATH=$PATH:$GRADLE_HOME/bin
+
+COPY . /gradle
+RUN sed -e "s/\${codenarc.version}/$CODENARC_VERSION/" -e "s/\${groovy.version}/$GROOVY_VERSION/" build.gradle.template > build.gradle
+
+RUN gradle --quiet --no-daemon shadowJar
+
+WORKDIR /work
+COPY . /work
+
+ENTRYPOINT ["java", "-jar", "/gradle/build/libs/codenarc-all.jar"]
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,6 @@ COPY --from=gradle /gradle/build/libs/codenarc-all.jar /lib/codenarc-all.jar
 RUN chmod 755 /lib/codenarc-all.jar
 
 WORKDIR /work
-COPY . /work
 
 ENTRYPOINT ["java", "-jar", "/lib/codenarc-all.jar"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /lib
 COPY --from=gradle /gradle/build/libs/codenarc-all.jar /lib/codenarc-all.jar
 RUN chmod 755 /lib/codenarc-all.jar
 
-WORKDIR /work
+WORKDIR /ws
 
 ENTRYPOINT ["java", "-jar", "/lib/codenarc-all.jar"]
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,14 @@
+# README for CodeNarc Dockerfile
+
+To build the image:
+
+    docker build -t codenarc .
+    # or
+    docker build -t codenarc --build-arg CODENARC_VERSION=1.6.1 --build-arg GROOVY_VERSION=3.0.6 .
+
+To run:
+
+    docker run --rm -v `pwd`:/ws --user `id -u`:`id -g` codenarc
+            
+    # or (assumes there is a "codenarc.ruleset" file in the current directory)
+    docker run --rm -v `pwd`:/ws --user `id -u`:`id -g` codenarc -report=json -rulesetfiles=file:codenarc.ruleset

--- a/docker/build.gradle.template
+++ b/docker/build.gradle.template
@@ -1,0 +1,32 @@
+plugins {
+    id 'java'
+    id 'com.github.johnrengelman.shadow' version '6.1.0'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile 'org.codehaus.groovy:groovy:${groovy.version}'
+    compile 'org.codehaus.groovy:groovy-xml:${groovy.version}'
+    compile 'org.codehaus.groovy:groovy-json:${groovy.version}'
+    compile 'org.codehaus.groovy:groovy-ant:${groovy.version}'
+    compile 'org.codehaus.groovy:groovy-templates:${groovy.version}'
+
+    compile('org.codenarc:CodeNarc:${codenarc.version}') {
+        exclude group: 'org.codehaus.groovy'
+    }
+
+    compile 'ch.qos.logback:logback-classic:1.2.3'
+}
+
+shadowJar {
+    archiveBaseName.set('codenarc-all')
+    archiveClassifier.set('')
+    archiveVersion.set('')
+    manifest {
+        attributes 'Main-Class': 'org.codenarc.CodeNarc'
+    }
+}
+


### PR DESCRIPTION
Dockerfile to build CodeNarc Docker image using Gradle and Shadowjar, allowing specification of Groovy and CodeNarc versions.

An alternative to the options presented in #568.

To build the image:
```
docker build -t codenarc .
# or
docker build -t codenarc --build-arg CODENARC_VERSION=1.6.1 --build-arg GROOVY_VERSION=3.0.6 .
```

To run (assumes there is a "codenarc.ruleset" file in the current directory):
```
docker run --rm -v $(pwd):/work --user $(id -u):$(id -g) codenarc -rulesetfiles=file:codenarc.ruleset
```

