### PR TITLE
Ignore pointcuts for empty methods

### DIFF
--- a/src/main/groovy/org/codenarc/rule/basic/EmptyMethodRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/basic/EmptyMethodRule.groovy
@@ -36,7 +36,10 @@ class EmptyMethodRule extends AbstractAstVisitorRule {
 class EmptyMethodAstVisitor extends AbstractMethodVisitor {
     @Override
     void visitMethod(MethodNode node) {
-        if (AstUtil.isEmptyBlock(node.code) && !Modifier.isAbstract(node.declaringClass.modifiers)) {
+        boolean isNotPointcutMethod = !AstUtil.hasAnnotation(node, 'Pointcut')
+        boolean isNotOverride = !Modifier.isAbstract(node.declaringClass.modifiers)
+
+        if (AstUtil.isEmptyBlock(node.code) && isNotOverride && isNotPointcutMethod) {
             if (!node.annotations.find { it?.classNode?.name == 'Override' }) {
                 addViolation(node, "The method $node.name is both empty and not marked with @Override")
             }

--- a/src/test/groovy/org/codenarc/rule/basic/EmptyMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/basic/EmptyMethodRuleTest.groovy
@@ -32,7 +32,7 @@ class EmptyMethodRuleTest extends AbstractRuleTestCase<EmptyMethodRule> {
     }
 
     @Test
-    void testSuccessScenario() {
+    void testOverrideScenario() {
         final SOURCE = '''
             class MyClass {
                 @Override
@@ -45,6 +45,17 @@ class EmptyMethodRuleTest extends AbstractRuleTestCase<EmptyMethodRule> {
             abstract class MyBaseClass {
                 // OK, handled by EmptyMethodInAbstractClass Rule
                 public void method() {}
+            }
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testPointcutScenario() {
+        final SOURCE = '''
+            class MyClass {
+                @Pointcut("@annotation(example.annotation.Test)")
+                public void method1() {}
             }
         '''
         assertNoViolations(SOURCE)


### PR DESCRIPTION
AspectJ pointcut declarations are empty methods, should be ignored.