### PR TITLE
Rename MethodCallNameTrailingWhitespaceRule to SpaceAfterMethodCallNameRule and MethodDeclarationNameTrailingWhitespaceRule to SpaceAfterMethodDeclarationNameRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ Build and Infrastructure
 
 New Rules
  - #580: New **SpaceAfterNotOperator** rule (formatting) - Checks if whitespace does directly follow usages of not operator. ([Marcin Erdmann](https://github.com/erdi))
- - #586: New **MethodCallNameTrailingWhitespace** rule (formatting) - Checks that there is no trailing whitespace in the method name when a method call contains parenthesis or that there is at most one space after the method name if the call does not contain parenthesis. ([Marcin Erdmann](https://github.com/erdi))
- - #584: New **MethodDeclarationNameTrailingWhitespaceRule** rule (formatting) - Checks whether method declarations do not contain unnecessary whitespace between method name and the opening parenthesis for parameter list. ([Marcin Erdmann](https://github.com/erdi))
+ - #586: New **SpaceAfterMethodCallName** rule (formatting) - Checks that there is no whitespace after the method name when a method call contains parenthesis or that there is at most one space after the method name if the call does not contain parenthesis. ([Marcin Erdmann](https://github.com/erdi))
+ - #584: New **SpaceAfterMethodDeclarationName** rule (formatting) - Checks whether method declarations do not contain unnecessary whitespace between method name and the opening parenthesis for parameter list. ([Marcin Erdmann](https://github.com/erdi))
  - #582: New **NoBlankLineBeforeAnnotatedField** rule (formatting) - Checks that there is a blank line before a field declaration that uses annotations. ([Marcin Erdmann](https://github.com/erdi))
 
 Version 2.0.0    (Oct 2020)

--- a/docs/codenarc-rules-formatting.md
+++ b/docs/codenarc-rules-formatting.md
@@ -464,7 +464,7 @@ applyToFilesMatching and doNotApplyToFilesMatching.
 | ignorePackageStatements     | If `true`, then do not apply this rule to package statements.| `true` |
 | ignoreLineRegex             | If specified, then ignore lines matching this regular expression.| `null` |
 
-## MethodDeclarationNameTrailingWhitespace Rule
+## SpaceAfterMethodDeclarationName Rule
 
 *Since CodeNarc 2.1*
 
@@ -484,11 +484,11 @@ Examples of violations:
     }
 ```
 
-## MethodCallNameTrailingWhitespace Rule
+## SpaceAfterMethodCallName Rule
 
 *Since CodeNarc 2.1*
 
-Checks that there is no trailing whitespace in the method name when a method call contains parenthesis or that there 
+Checks that there is no whitespace after the method name when a method call contains parenthesis or that there 
 is at most one space after the method name if the call does not contain parenthesis.
 
 Examples of violations:

--- a/src/main/groovy/org/codenarc/rule/formatting/SpaceAfterMethodCallNameRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/SpaceAfterMethodCallNameRule.groovy
@@ -22,17 +22,17 @@ import org.codenarc.rule.AbstractAstVisitor
 import org.codenarc.rule.AbstractAstVisitorRule
 
 /**
- * Checks that there is no trailing whitespace in the method name when a method call contains parenthesis or that
+ * Checks that there is no whitespace at the end of the method name when a method call contains parenthesis or that
  * there is at most one space after the method name if the call does not contain parenthesis
  */
-class MethodCallNameTrailingWhitespaceRule extends AbstractAstVisitorRule {
+class SpaceAfterMethodCallNameRule extends AbstractAstVisitorRule {
 
-    String name = 'MethodCallNameTrailingWhitespace'
+    String name = 'SpaceAfterMethodCallName'
     int priority = 3
-    Class astVisitorClass = MethodCallNameTrailingWhitespaceRuleAstVisitor
+    Class astVisitorClass = SpaceAfterMethodCallNameRuleAstVisitor
 }
 
-class MethodCallNameTrailingWhitespaceRuleAstVisitor extends AbstractAstVisitor {
+class SpaceAfterMethodCallNameRuleAstVisitor extends AbstractAstVisitor {
 
     @Override
     void visitConstructorCallExpression(ConstructorCallExpression call) {

--- a/src/main/groovy/org/codenarc/rule/formatting/SpaceAfterMethodDeclarationNameRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/SpaceAfterMethodDeclarationNameRule.groovy
@@ -23,14 +23,14 @@ import org.codenarc.rule.AbstractAstVisitorRule
  * Check whether method declarations do not contain unnecessary whitespace between method name and the opening
  * parenthesis for parameter list.
  */
-class MethodDeclarationNameTrailingWhitespaceRule extends AbstractAstVisitorRule {
+class SpaceAfterMethodDeclarationNameRule extends AbstractAstVisitorRule {
 
-    String name = 'MethodDeclarationNameTrailingWhitespace'
+    String name = 'SpaceAfterMethodDeclarationName'
     int priority = 3
-    Class astVisitorClass = MethodDeclarationNameTrailingWhitespaceRuleAstVisitor
+    Class astVisitorClass = SpaceAfterMethodDeclarationNameRuleAstVisitor
 }
 
-class MethodDeclarationNameTrailingWhitespaceRuleAstVisitor extends AbstractAstVisitor {
+class SpaceAfterMethodDeclarationNameRuleAstVisitor extends AbstractAstVisitor {
 
     @Override
     protected void visitConstructorOrMethod(MethodNode node, boolean isConstructor) {

--- a/src/main/resources/codenarc-base-messages.properties
+++ b/src/main/resources/codenarc-base-messages.properties
@@ -1201,11 +1201,11 @@ CouldBeSwitchStatement.description.html=Checks for multiple if statements that c
 CompileStatic.description=Check that classes are explicitely annotated with either @GrailsCompileStatic, @CompileStatic or @CompileDynamic
 CompileStatic.description.html=Check that classes are explicitely annotated with either @GrailsCompileStatic, @CompileStatic or @CompileDynamic
 
-MethodCallNameTrailingWhitespace.description=Checks that there is no trailing whitespace in the method name when a method call contains parenthesis or that there is at most one space after the method name if the call does not contain parenthesis.
-MethodCallNameTrailingWhitespace.description.html=Checks that there is no trailing whitespace in the method name when a method call contains parenthesis or that there is at most one space after the method name if the call does not contain parenthesis.
+SpaceAfterMethodCallName.description=Checks that there is whitespace after the method name when a method call contains parenthesis or that there is at most one space after the method name if the call does not contain parenthesis.
+SpaceAfterMethodCallName.description.html=Checks that there is no whitespace after the method name when a method call contains parenthesis or that there is at most one space after the method name if the call does not contain parenthesis.
 
-MethodDeclarationNameTrailingWhitespace.description=Check whether method declarations do not contain unnecessary whitespace between method name and the opening parenthesis for parameter list.
-MethodDeclarationNameTrailingWhitespace.description.html=Check whether method declarations do not contain unnecessary whitespace between method name and the opening parenthesis for parameter list.
+SpaceAfterMethodDeclarationName.description=Check whether method declarations do not contain unnecessary whitespace between method name and the opening parenthesis for parameter list.
+SpaceAfterMethodDeclarationName.description.html=Check whether method declarations do not contain unnecessary whitespace between method name and the opening parenthesis for parameter list.
 
 #-----------------------------------------------------------------------------------------
 # Report labels, etc.

--- a/src/main/resources/rulesets/formatting.xml
+++ b/src/main/resources/rulesets/formatting.xml
@@ -21,8 +21,8 @@
     <rule class='org.codenarc.rule.formatting.FileEndsWithoutNewlineRule'/>
     <rule class='org.codenarc.rule.formatting.IndentationRule'/>
     <rule class='org.codenarc.rule.formatting.LineLengthRule'/>
-    <rule class='org.codenarc.rule.formatting.MethodCallNameTrailingWhitespaceRule'/>
-    <rule class='org.codenarc.rule.formatting.MethodDeclarationNameTrailingWhitespaceRule'/>
+    <rule class='org.codenarc.rule.formatting.SpaceAfterMethodCallNameRule'/>
+    <rule class='org.codenarc.rule.formatting.SpaceAfterMethodDeclarationNameRule'/>
     <rule class='org.codenarc.rule.formatting.MissingBlankLineAfterImportsRule'/>
     <rule class='org.codenarc.rule.formatting.MissingBlankLineAfterPackageRule'/>
     <rule class='org.codenarc.rule.formatting.NoBlankLineBeforeAnnotatedFieldRule'/>

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterMethodCallNameRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterMethodCallNameRuleTest.groovy
@@ -19,14 +19,14 @@ import org.codenarc.rule.AbstractRuleTestCase
 import org.junit.Test
 
 /**
- * Tests for MethodCallNameTrailingWhitespaceRule
+ * Tests for SpaceAfterMethodCallNameRule
  */
-class MethodCallNameTrailingWhitespaceRuleTest extends AbstractRuleTestCase<MethodCallNameTrailingWhitespaceRule> {
+class SpaceAfterMethodCallNameRuleTest extends AbstractRuleTestCase<SpaceAfterMethodCallNameRule> {
 
     @Test
     void ruleProperties() {
         assert rule.priority == 3
-        assert rule.name == 'MethodCallNameTrailingWhitespace'
+        assert rule.name == 'SpaceAfterMethodCallName'
     }
 
     @Test
@@ -135,7 +135,7 @@ class MethodCallNameTrailingWhitespaceRuleTest extends AbstractRuleTestCase<Meth
     }
 
     @Override
-    protected MethodCallNameTrailingWhitespaceRule createRule() {
-        new MethodCallNameTrailingWhitespaceRule()
+    protected SpaceAfterMethodCallNameRule createRule() {
+        new SpaceAfterMethodCallNameRule()
     }
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterMethodDeclarationNameRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterMethodDeclarationNameRuleTest.groovy
@@ -19,14 +19,14 @@ import org.codenarc.rule.AbstractRuleTestCase
 import org.junit.Test
 
 /**
- * Tests for MethodDeclarationNameTrailingWhitespaceRule
+ * Tests for SpaceAfterMethodDeclarationNameRule
  */
-class MethodDeclarationNameTrailingWhitespaceRuleTest extends AbstractRuleTestCase<MethodDeclarationNameTrailingWhitespaceRule> {
+class SpaceAfterMethodDeclarationNameRuleTest extends AbstractRuleTestCase<SpaceAfterMethodDeclarationNameRule> {
 
     @Test
     void ruleProperties() {
         assert rule.priority == 3
-        assert rule.name == 'MethodDeclarationNameTrailingWhitespace'
+        assert rule.name == 'SpaceAfterMethodDeclarationName'
     }
 
     @Test
@@ -96,7 +96,7 @@ class MethodDeclarationNameTrailingWhitespaceRuleTest extends AbstractRuleTestCa
     }
 
     @Override
-    protected MethodDeclarationNameTrailingWhitespaceRule createRule() {
-        new MethodDeclarationNameTrailingWhitespaceRule()
+    protected SpaceAfterMethodDeclarationNameRule createRule() {
+        new SpaceAfterMethodDeclarationNameRule()
     }
 }


### PR DESCRIPTION
As discussed in #585.