### PR TITLE
allow CodeNarc prefix in suppress warnings

### DIFF
--- a/src/main/groovy/org/codenarc/analyzer/SuppressionAnalyzer.java
+++ b/src/main/groovy/org/codenarc/analyzer/SuppressionAnalyzer.java
@@ -34,7 +34,10 @@ public class SuppressionAnalyzer {
 
     public boolean isRuleSuppressed(Rule rule) {
         init();
-        return suppressedRuleNames.contains(rule.getName()) || suppressedRuleNames.contains(ALL) || suppressedRuleNames.contains(CODE_NARC);
+        return suppressedRuleNames.contains(rule.getName())
+            || suppressedRuleNames.contains(CODE_NARC + "." + rule.getName())
+            || suppressedRuleNames.contains(ALL)
+            || suppressedRuleNames.contains(CODE_NARC);
     }
 
     public List<Violation> filterSuppressedViolations(Iterable<Violation> violations) {

--- a/src/test/groovy/org/codenarc/analyzer/SuppressionAnalyzerTest.groovy
+++ b/src/test/groovy/org/codenarc/analyzer/SuppressionAnalyzerTest.groovy
@@ -42,7 +42,7 @@ class SuppressionAnalyzerTest extends AbstractTestCase {
         def analyzer = new SuppressionAnalyzer(new SourceString('''
 
             @SuppressWarnings('Rule1')
-            @SuppressWarnings(['Rule2', 'Rule3'])
+            @SuppressWarnings(['Rule2', 'CodeNarc.Rule3'])
             package foo
 
             println 4


### PR DESCRIPTION
in the new version of CodeNarc IntelliJ plugin I register the inspections under `CodeNarc.<rule name>` id to guarantee uniqueness across other plugins. Sadly, thanks to this the suppression action now generates the annotation including the prefix. This behaviour cannot be charged as the method responsible for generating the suppression id is final.

You can check the latest implementation of the plugin on the beta channel

https://github.com/melix/codenarc-idea#beta-channel