### PR TITLE
MissingBlankLineBeforeAnnotatedFieldRule should work when class is annotated

### DIFF
--- a/src/main/groovy/org/codenarc/rule/formatting/MissingBlankLineBeforeAnnotatedFieldRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/MissingBlankLineBeforeAnnotatedFieldRule.groovy
@@ -46,7 +46,7 @@ class MissingBlankLineBeforeAnnotatedFieldRuleAstVisitor extends AbstractAstVisi
     }
 
     private boolean annotationIsNotOnFirstLineOfClass(FieldNode node) {
-        node.lineNumber != getCurrentClassNode().lineNumber + 1
+        node.lineNumber != AstUtil.findFirstNonAnnotationLine(getCurrentClassNode(), sourceCode) + 1
     }
 
     private boolean annotationsNotOnSameLineAsFieldDeclaration(FieldNode node) {

--- a/src/test/groovy/org/codenarc/rule/formatting/MissingBlankLineBeforeAnnotatedFieldRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/MissingBlankLineBeforeAnnotatedFieldRuleTest.groovy
@@ -138,6 +138,32 @@ class MissingBlankLineBeforeAnnotatedFieldRuleTest extends AbstractRuleTestCase<
         assertNoViolations(SOURCE)
     }
 
+    @Test
+    void test_AnnotationOnTheFirstLineOfTheClassWithAnnotations_NoViolation() {
+        final SOURCE = '''
+            @SomeClassAnnotation
+            abstract class JerseySpec extends Specification {
+                @Delegate
+                private JerseyTest jerseyTest
+            }
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void test_AnnotationOnTheFirstLineOfTheClassWithMultipleAnnotations_NoViolation() {
+        final SOURCE = '''
+            @SomeClassAnnotation1
+            @SomeClassAnnotation2
+            @SomeClassAnnotation3
+            abstract class JerseySpec extends Specification {
+                @Delegate
+                private JerseyTest jerseyTest
+            }
+        '''
+        assertNoViolations(SOURCE)
+    }
+
     @Override
     protected MissingBlankLineBeforeAnnotatedFieldRule createRule() {
         new MissingBlankLineBeforeAnnotatedFieldRule()


### PR DESCRIPTION
Proposed bug fix for https://github.com/CodeNarc/CodeNarc/issues/632