### PR TITLE
BracesForMethod - allow braces in new line for multiline declarations

### DIFF
--- a/src/main/groovy/org/codenarc/rule/formatting/BracesForMethodRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/BracesForMethodRule.groovy
@@ -32,7 +32,7 @@ class BracesForMethodRule extends AbstractAstVisitorRule {
     int priority = 2
     Class astVisitorClass = BracesForMethodAstVisitor
     boolean sameLine = true
-    boolean whenSameLineAllowNewLineForMultilineDeclarations = false
+    boolean allowBraceOnNextLineForMultilineDeclarations = false
 }
 
 class BracesForMethodAstVisitor extends AbstractAstVisitor {
@@ -46,7 +46,7 @@ class BracesForMethodAstVisitor extends AbstractAstVisitor {
         boolean containsRegex = hasOpeningBraceOnSameLine(node)
 
         if (rule.sameLine && !containsRegex) {
-            if (!(rule.whenSameLineAllowNewLineForMultilineDeclarations && isMultilineWithOpeningBraceInNewLine(node))) {
+            if (!(rule.allowBraceOnNextLineForMultilineDeclarations && isMultilineWithOpeningBraceInNewLine(node))) {
                 addViolation(node, "Opening brace for the method $node.name should start on the same line")
             }
         }

--- a/src/main/groovy/org/codenarc/rule/formatting/BracesForMethodRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/BracesForMethodRule.groovy
@@ -46,10 +46,7 @@ class BracesForMethodAstVisitor extends AbstractAstVisitor {
         boolean containsRegex = hasOpeningBraceOnSameLine(node)
 
         if (rule.sameLine && !containsRegex) {
-            if (rule.whenSameLineAllowNewLineForMultilineDeclarations && isMultilineWithOpeningBraceInNewLine(node)) {
-                // noop
-            }
-            else {
+            if (!(rule.whenSameLineAllowNewLineForMultilineDeclarations && isMultilineWithOpeningBraceInNewLine(node))) {
                 addViolation(node, "Opening brace for the method $node.name should start on the same line")
             }
         }

--- a/src/main/groovy/org/codenarc/rule/formatting/BracesForMethodRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/BracesForMethodRule.groovy
@@ -32,6 +32,7 @@ class BracesForMethodRule extends AbstractAstVisitorRule {
     int priority = 2
     Class astVisitorClass = BracesForMethodAstVisitor
     boolean sameLine = true
+    boolean whenSameLineAllowNewLineForMultilineDeclarations = false
 }
 
 class BracesForMethodAstVisitor extends AbstractAstVisitor {
@@ -45,7 +46,12 @@ class BracesForMethodAstVisitor extends AbstractAstVisitor {
         boolean containsRegex = hasOpeningBraceOnSameLine(node)
 
         if (rule.sameLine && !containsRegex) {
-            addViolation(node, "Opening brace for the method $node.name should start on the same line")
+            if (rule.whenSameLineAllowNewLineForMultilineDeclarations && isMultilineWithOpeningBraceInNewLine(node)) {
+                // noop
+            }
+            else {
+                addViolation(node, "Opening brace for the method $node.name should start on the same line")
+            }
         }
 
         if (!rule.sameLine && containsRegex) {
@@ -73,6 +79,18 @@ class BracesForMethodAstVisitor extends AbstractAstVisitor {
         def range = node.exceptions[0].lineNumber .. node.exceptions[-1].lastLineNumber
         def lines = range.collect { lineNumber -> sourceCode.line(lineNumber - 1) }
         return lines.join(' ')
+    }
+
+    private boolean isMultilineWithOpeningBraceInNewLine(MethodNode methodNode) {
+        int firstLineOfDeclaration = methodNode.lineNumber
+        int lastLineOfDeclaration = methodNode.parameters ? methodNode.parameters[-1].lineNumber : methodNode.lineNumber
+        lastLineOfDeclaration = methodNode.exceptions ? methodNode.exceptions[-1].lineNumber : lastLineOfDeclaration
+
+        if (firstLineOfDeclaration == lastLineOfDeclaration) {
+            return false
+        }
+
+        return sourceCode.line(methodNode.code.lineNumber - 1).trim() == '{'
     }
 
 }

--- a/src/main/groovy/org/codenarc/rule/formatting/BracesForMethodRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/BracesForMethodRule.groovy
@@ -87,7 +87,7 @@ class BracesForMethodAstVisitor extends AbstractAstVisitor {
             return false
         }
 
-        return sourceCode.line(methodNode.code.lineNumber - 1).trim() == '{'
+        return sourceCode.line(methodNode.code.lineNumber - 1).trim().startsWith('{')
     }
 
 }

--- a/src/test/groovy/org/codenarc/rule/formatting/BracesForMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/BracesForMethodRuleTest.groovy
@@ -433,7 +433,7 @@ class BracesForMethodRuleTest extends AbstractRuleTestCase<BracesForMethodRule> 
     }
 
     @Test
-    void test_OpeningBraceIsOnItsOwnLine_whenSameLineAllowNewLineForMultilineDeclarationsTrue_NoViolations() {
+    void test_OpeningBraceIsOnItsOwnLine_allowBraceOnNextLineForMultilineDeclarationsTrue_NoViolations() {
         final SOURCE = '''
             class RemoteWebDriverWithExpectations {
                 RemoteWebDriverWithExpectations(
@@ -445,12 +445,12 @@ class BracesForMethodRuleTest extends AbstractRuleTestCase<BracesForMethodRule> 
             }
         '''
         rule.sameLine = true
-        rule.whenSameLineAllowNewLineForMultilineDeclarations = true
+        rule.allowBraceOnNextLineForMultilineDeclarations = true
         assertNoViolations(SOURCE)
     }
 
     @Test
-    void test_OpeningBraceIsOnItsOwnLine_withExceptions_whenSameLineAllowNewLineForMultilineDeclarationsTrue_NoViolations() {
+    void test_OpeningBraceIsOnItsOwnLine_withExceptions_allowBraceOnNextLineForMultilineDeclarationsTrue_NoViolations() {
         final SOURCE = '''
             class RemoteWebDriverWithExpectations {
                 RemoteWebDriverWithExpectations(
@@ -463,12 +463,12 @@ class BracesForMethodRuleTest extends AbstractRuleTestCase<BracesForMethodRule> 
             }
         '''
         rule.sameLine = true
-        rule.whenSameLineAllowNewLineForMultilineDeclarations = true
+        rule.allowBraceOnNextLineForMultilineDeclarations = true
         assertNoViolations(SOURCE)
     }
 
     @Test
-    void test_OpeningBraceIsOnItsOwnLine_whenSameLineAllowNewLineForMultilineDeclarationsFalse_Violations() {
+    void test_OpeningBraceIsOnItsOwnLine_allowBraceOnNextLineForMultilineDeclarationsFalse_Violations() {
         final SOURCE = '''
             class RemoteWebDriverWithExpectations {
                 RemoteWebDriverWithExpectations(
@@ -480,12 +480,12 @@ class BracesForMethodRuleTest extends AbstractRuleTestCase<BracesForMethodRule> 
             }
         '''
         rule.sameLine = true
-        rule.whenSameLineAllowNewLineForMultilineDeclarations = false
+        rule.allowBraceOnNextLineForMultilineDeclarations = false
         assertSingleViolation(SOURCE, 3, 'RemoteWebDriverWithExpectations(', 'Opening brace for the method <init> should start on the same line')
     }
 
     @Test
-    void test_OpeningBraceIsOnItsOwnLine_withExceptions_whenSameLineAllowNewLineForMultilineDeclarationsFalse_Violations() {
+    void test_OpeningBraceIsOnItsOwnLine_withExceptions_allowBraceOnNextLineForMultilineDeclarationsFalse_Violations() {
         final SOURCE = '''
             class RemoteWebDriverWithExpectations {
                 RemoteWebDriverWithExpectations(
@@ -498,7 +498,7 @@ class BracesForMethodRuleTest extends AbstractRuleTestCase<BracesForMethodRule> 
             }
         '''
         rule.sameLine = true
-        rule.whenSameLineAllowNewLineForMultilineDeclarations = false
+        rule.allowBraceOnNextLineForMultilineDeclarations = false
         assertSingleViolation(SOURCE, 3, 'RemoteWebDriverWithExpectations(', 'Opening brace for the method <init> should start on the same line')
     }
 

--- a/src/test/groovy/org/codenarc/rule/formatting/BracesForMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/BracesForMethodRuleTest.groovy
@@ -450,6 +450,23 @@ class BracesForMethodRuleTest extends AbstractRuleTestCase<BracesForMethodRule> 
     }
 
     @Test
+    void test_OpeningBraceIsOnItsOwnLine_withLineComment_allowBraceOnNextLineForMultilineDeclarationsTrue_NoViolations() {
+        final SOURCE = '''
+            class RemoteWebDriverWithExpectations {
+                RemoteWebDriverWithExpectations(
+                    URL remoteAddress, Capabilities capabilities, List<String> ignoredCommands = DEFAULT_IGNORED_COMMANDS)
+                { // Some comment
+                    super(remoteAddress, capabilities)
+                    this.ignoredCommands = ignoredCommands
+                }
+            }
+        '''
+        rule.sameLine = true
+        rule.allowBraceOnNextLineForMultilineDeclarations = true
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
     void test_OpeningBraceIsOnItsOwnLine_withExceptions_allowBraceOnNextLineForMultilineDeclarationsTrue_NoViolations() {
         final SOURCE = '''
             class RemoteWebDriverWithExpectations {
@@ -457,6 +474,24 @@ class BracesForMethodRuleTest extends AbstractRuleTestCase<BracesForMethodRule> 
                     URL remoteAddress, Capabilities capabilities, List<String> ignoredCommands = DEFAULT_IGNORED_COMMANDS)
                     throws Exception, OtherException
                 {
+                    super(remoteAddress, capabilities)
+                    this.ignoredCommands = ignoredCommands
+                }
+            }
+        '''
+        rule.sameLine = true
+        rule.allowBraceOnNextLineForMultilineDeclarations = true
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void test_OpeningBraceIsOnItsOwnLine_withExceptions_withLineComment_allowBraceOnNextLineForMultilineDeclarationsTrue_NoViolations() {
+        final SOURCE = '''
+            class RemoteWebDriverWithExpectations {
+                RemoteWebDriverWithExpectations(
+                    URL remoteAddress, Capabilities capabilities, List<String> ignoredCommands = DEFAULT_IGNORED_COMMANDS)
+                    throws Exception, OtherException
+                { // Some comment
                     super(remoteAddress, capabilities)
                     this.ignoredCommands = ignoredCommands
                 }

--- a/src/test/groovy/org/codenarc/rule/formatting/BracesForMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/BracesForMethodRuleTest.groovy
@@ -432,6 +432,76 @@ class BracesForMethodRuleTest extends AbstractRuleTestCase<BracesForMethodRule> 
         assertNoViolations(SOURCE)
     }
 
+    @Test
+    void test_OpeningBraceIsOnItsOwnLine_whenSameLineAllowNewLineForMultilineDeclarationsTrue_NoViolations() {
+        final SOURCE = '''
+            class RemoteWebDriverWithExpectations {
+                RemoteWebDriverWithExpectations(
+                    URL remoteAddress, Capabilities capabilities, List<String> ignoredCommands = DEFAULT_IGNORED_COMMANDS) 
+                {
+                    super(remoteAddress, capabilities)
+                    this.ignoredCommands = ignoredCommands
+                }
+            }
+        '''
+        rule.sameLine = true
+        rule.whenSameLineAllowNewLineForMultilineDeclarations = true
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void test_OpeningBraceIsOnItsOwnLine_withExceptions_whenSameLineAllowNewLineForMultilineDeclarationsTrue_NoViolations() {
+        final SOURCE = '''
+            class RemoteWebDriverWithExpectations {
+                RemoteWebDriverWithExpectations(
+                    URL remoteAddress, Capabilities capabilities, List<String> ignoredCommands = DEFAULT_IGNORED_COMMANDS)
+                    throws Exception, OtherException
+                {
+                    super(remoteAddress, capabilities)
+                    this.ignoredCommands = ignoredCommands
+                }
+            }
+        '''
+        rule.sameLine = true
+        rule.whenSameLineAllowNewLineForMultilineDeclarations = true
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void test_OpeningBraceIsOnItsOwnLine_whenSameLineAllowNewLineForMultilineDeclarationsFalse_Violations() {
+        final SOURCE = '''
+            class RemoteWebDriverWithExpectations {
+                RemoteWebDriverWithExpectations(
+                    URL remoteAddress, Capabilities capabilities, List<String> ignoredCommands = DEFAULT_IGNORED_COMMANDS)
+                {
+                    super(remoteAddress, capabilities)
+                    this.ignoredCommands = ignoredCommands
+                }
+            }
+        '''
+        rule.sameLine = true
+        rule.whenSameLineAllowNewLineForMultilineDeclarations = false
+        assertSingleViolation(SOURCE, 3, 'RemoteWebDriverWithExpectations(', 'Opening brace for the method <init> should start on the same line')
+    }
+
+    @Test
+    void test_OpeningBraceIsOnItsOwnLine_withExceptions_whenSameLineAllowNewLineForMultilineDeclarationsFalse_Violations() {
+        final SOURCE = '''
+            class RemoteWebDriverWithExpectations {
+                RemoteWebDriverWithExpectations(
+                    URL remoteAddress, Capabilities capabilities, List<String> ignoredCommands = DEFAULT_IGNORED_COMMANDS)
+                    throws Exception, OtherException
+                {
+                    super(remoteAddress, capabilities)
+                    this.ignoredCommands = ignoredCommands
+                }
+            }
+        '''
+        rule.sameLine = true
+        rule.whenSameLineAllowNewLineForMultilineDeclarations = false
+        assertSingleViolation(SOURCE, 3, 'RemoteWebDriverWithExpectations(', 'Opening brace for the method <init> should start on the same line')
+    }
+
     @Override
     protected BracesForMethodRule createRule() {
         new BracesForMethodRule()

--- a/src/test/groovy/org/codenarc/rule/formatting/BracesForMethodRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/BracesForMethodRuleTest.groovy
@@ -437,7 +437,7 @@ class BracesForMethodRuleTest extends AbstractRuleTestCase<BracesForMethodRule> 
         final SOURCE = '''
             class RemoteWebDriverWithExpectations {
                 RemoteWebDriverWithExpectations(
-                    URL remoteAddress, Capabilities capabilities, List<String> ignoredCommands = DEFAULT_IGNORED_COMMANDS) 
+                    URL remoteAddress, Capabilities capabilities, List<String> ignoredCommands = DEFAULT_IGNORED_COMMANDS)
                 {
                     super(remoteAddress, capabilities)
                     this.ignoredCommands = ignoredCommands


### PR DESCRIPTION
Here is a proposal for BracesForMethod rule enhancement as described in https://github.com/CodeNarc/CodeNarc/issues/611