### PR TITLE
Fix parameter table for PackageName Rule documentation

### DIFF
--- a/docs/codenarc-rules-naming.md
+++ b/docs/codenarc-rules-naming.md
@@ -230,7 +230,7 @@ package name consists of only lowercase letters and numbers, separated by period
 
 | Property                    | Description            | Default Value    |
 |-----------------------------|------------------------|------------------|
-| regex                       | Specifies the regular expression used to validate the package  |   | name. It is required and cannot be null or empty.              | \[a-z\]+\[a-z0-9\]*(\\.\[a-z0-9\]+)* |
+| regex                       | Specifies the regular expression used to validate the package name. It is required and cannot be null or empty. | \[a-z\]+\[a-z0-9\]*(\\.\[a-z0-9\]+)* |
 | packageNameRequired         | Indicates whether a package name declaration is required for all classes.  | `false`                     |
 
 


### PR DESCRIPTION
The parameter table for the `PackageNameRule` documentation has some extra cells, this pull request fixes the formatting.