### PR TITLE
Support for description inside CodeNarc comments

### DIFF
--- a/src/main/groovy/org/codenarc/plugin/disablerules/LookupTable.groovy
+++ b/src/main/groovy/org/codenarc/plugin/disablerules/LookupTable.groovy
@@ -26,6 +26,7 @@ class LookupTable {
     private static final String CODENARC_DISABLE = 'codenarc-disable'
     private static final String CODENARC_DISABLE_LINE = 'codenarc-disable-line'
     private static final String CODENARC_ENABLE = 'codenarc-enable'
+    private static final String CODENARC_DESCRIPTION_START = '--'
     private static final Set<String> EMPTY = []
 
     private final String sourceText
@@ -104,7 +105,9 @@ class LookupTable {
         int startIndex = index + codeNarcToken.length()
         String rawRestOfLine = line.substring(startIndex)
         String restOfLine = rawRestOfLine.trim().replaceAll(/\*\//, '')
-        def names = restOfLine.tokenize(',')
+        int descriptionIndex = restOfLine.indexOf(CODENARC_DESCRIPTION_START)
+        String rawNames = descriptionIndex > -1 ? restOfLine.substring(0, descriptionIndex) : restOfLine
+        def names = rawNames.tokenize(',')
         return names*.trim() as Set
     }
 

--- a/src/test/groovy/org/codenarc/plugin/disablerules/DisableRulesInCommentsPluginTest.groovy
+++ b/src/test/groovy/org/codenarc/plugin/disablerules/DisableRulesInCommentsPluginTest.groovy
@@ -202,6 +202,19 @@ class DisableRulesInCommentsPluginTest extends AbstractTestCase {
         assertAllViolationsEnabled()
     }
 
+    @Test
+    void test_processViolationsForFile_RuleWithInlineDescription() {
+        sourceText = '''
+            class MyClass {         /* codenarc-enable */
+                def value = 123     /* codenarc-disable-line OtherRule -- should not disable rule as it part of the description: Rule2, Rule1 */
+                void doStuff() {
+                    println 123     /* codenarc-disable-line Rule1 -- should disable rule */
+                }
+            }
+        '''.trim()
+        assertViolationsThatAreEnabled([VIOLATION1, VIOLATION2, VIOLATION3, VIOLATION5])
+    }
+
     // Helper methods
 
     private void assertAllViolationsEnabled() {


### PR DESCRIPTION
In our projects we have the policy that every disabled rule from a static code analysis tool has to be annotated with an appropriate description or reason. Other tools we are using like SonarQube or ESLint do have support for this, for example:
```
// NOSONAR my description
// eslint-disable-next-line no-console -- Here's a description about why this configuration is necessary.
```

Unfortunately this is not yet supported by CodeNarc.
If possible I would like to contribute this feature, since it would be helpful to have it in our projects.
