### PR TITLE
MissingBlankLineBeforeAnnotatedFieldRule proposed fix

### DIFF
--- a/src/main/java/org/codenarc/util/AstUtil.java
+++ b/src/main/java/org/codenarc/util/AstUtil.java
@@ -1116,6 +1116,12 @@ public class AstUtil {
             // is the annotation the last thing on the line?
             if (rawLine.length() > lastAnnotation.getLastColumnNumber()) {
                 // no it is not
+
+                boolean doesItEndsWithLineComment = rawLine.substring(lastAnnotation.getLastColumnNumber() - 1).trim().startsWith("//");
+                if (doesItEndsWithLineComment) {
+                    return lastAnnotation.getLastLineNumber() + 1;
+                }
+
                 if (node.getClass() == MethodNode.class) {      // methods, but not constructors (since their name is different)
                     if (rawLine.contains(((MethodNode) node).getName())) {
                         return lastAnnotation.getLastLineNumber();

--- a/src/test/groovy/org/codenarc/rule/formatting/IndentationRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/IndentationRuleTest.groovy
@@ -171,7 +171,7 @@ class IndentationRuleTest extends AbstractRuleTestCase<IndentationRule> {
             |}
         '''.stripMargin()
         assertViolations(SOURCE,
-                [line: 5, source: '@Component', message: 'The class MyOtherClass'],
+                [line: 6, source: 'class MyOtherClass { }', message: 'The class MyOtherClass'],
                 [line: 16, source: '@Package void two()', message: 'The method two in class TestClass'],
                 [line: 22, source: 'private String name', message: 'The field name in class TestClass'])
     }

--- a/src/test/groovy/org/codenarc/rule/formatting/MissingBlankLineBeforeAnnotatedFieldRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/MissingBlankLineBeforeAnnotatedFieldRuleTest.groovy
@@ -164,6 +164,18 @@ class MissingBlankLineBeforeAnnotatedFieldRuleTest extends AbstractRuleTestCase<
         assertNoViolations(SOURCE)
     }
 
+    @Test
+    void test_AnnotationOnTheFirstLineOfTheClassWithAnnotationAndLineComment_NoViolation() {
+        final SOURCE = '''
+            @SomeClassAnnotation3 // Some comment
+            abstract class JerseySpec extends Specification {
+                @Delegate
+                private JerseyTest jerseyTest
+            }
+        '''
+        assertNoViolations(SOURCE)
+    }
+
     @Override
     protected MissingBlankLineBeforeAnnotatedFieldRule createRule() {
         new MissingBlankLineBeforeAnnotatedFieldRule()


### PR DESCRIPTION
This is a proposed PR for https://github.com/CodeNarc/CodeNarc/issues/662

The solution proposed relies on changes in `AstUtil` which might have wide consequences.
I didn't find problems, except with `IndentationRuleTest` that requires a small change.
However, it looks good to me because when reporting violations for annotated node, `AbstractAstVisitor.addViolation(ASTNode, String)` reports the first non-annotation line as a violation.