### PR TITLE
Fix running tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,11 @@ sourceSets {
     }
 }
 
-test.maxParallelForks = 2
-test.jvmArgs '-Duser.language=en -Duser.country=US'
+test {
+    useJUnitPlatform()
+    maxParallelForks = 2
+    jvmArgs '-Duser.language=en -Duser.country=US'
+}
 
 java {
     //withJavadocJar()


### PR DESCRIPTION
Without enabling the JUnit feature no tests are run when using `./gradlew check`.

Reference: https://junit.org/junit5/docs/5.8.2/user-guide/#running-tests-build-gradle