### PR TITLE
SpaceAfterMethodCallName: Fix handling methods with special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Build and Infrastructure
  - #679: Use XmlParserFactory for Groovy 4 compatibility. ([Paul King](https://github.com/paulk-asert))
  - #682: Support Groovy 4.0.
  - #683: **UnnecessaryPublicModifier**: Fix StringIndexOutOfBoundsException.
+ - #686: **SpaceAfterMethodCallName**: Fix handling methods with special characters.
 
 
 Version 3.0.0    (Mar 2022)

--- a/src/main/groovy/org/codenarc/rule/formatting/SpaceAfterMethodCallNameRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/formatting/SpaceAfterMethodCallNameRule.groovy
@@ -21,6 +21,8 @@ import org.codenarc.rule.AbstractAstVisitor
 import org.codenarc.rule.AbstractAstVisitorRule
 import org.codenarc.rule.Violation
 
+import java.util.regex.Pattern
+
 /**
  * Checks that there is no whitespace at the end of the method name when a method call contains parenthesis or that
  * there is at most one space after the method name if the call does not contain parenthesis
@@ -57,7 +59,7 @@ class SpaceAfterMethodCallNameRuleAstVisitor extends AbstractAstVisitor {
         def arguments = call.arguments
         if (isFirstVisit(call) && method.lineNumber != -1 && method.lineNumber == arguments.lineNumber && !hasSingleLambdaArgument(call)) {
             String methodName = call.methodAsString
-            def regex = methodName + /\s+\(/
+            def regex = Pattern.quote(methodName) + /\s+\(/
             def lineNumbers = (method.lineNumber .. method.lastLineNumber)
             for (int lineNumber: lineNumbers) {
                 def line = sourceCode.line(lineNumber - 1)

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterMethodCallNameRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterMethodCallNameRuleTest.groovy
@@ -54,6 +54,13 @@ class SpaceAfterMethodCallNameRuleTest extends AbstractRuleTestCase<SpaceAfterMe
                 void aMethod(String argument) {
                 }
 
+                def aMethodWithSpecialRegexCharacter() {
+                    withFormat {
+                        json { }
+                        '*'  { }
+                    }
+                }
+
                 LinkedHashSet<String> set() {
                     new LinkedHashSet<Class<?>>()
                 }


### PR DESCRIPTION
This fixes #686.