### PR TITLE
Refactoring directory handling in results

### DIFF
--- a/src/main/groovy/org/codenarc/analyzer/FilesystemSourceAnalyzer.groovy
+++ b/src/main/groovy/org/codenarc/analyzer/FilesystemSourceAnalyzer.groovy
@@ -131,7 +131,6 @@ class FilesystemSourceAnalyzer extends AbstractSourceAnalyzer {
         if (matches(sourceFile)) {
             List allViolations = collectViolations(sourceFile, ruleSet)
             def fileResults = new FileResults(filePath, allViolations, sourceFile)
-            dirResults.numberOfFilesInThisDirectory++
             dirResults.addChild(fileResults)
         }
     }

--- a/src/main/groovy/org/codenarc/results/DirectoryResults.groovy
+++ b/src/main/groovy/org/codenarc/results/DirectoryResults.groovy
@@ -27,7 +27,6 @@ class DirectoryResults implements Results {
     private static final String SEP = '/'
     private final String path
     private final List children = []
-    int numberOfFilesInThisDirectory = 0
 
     /**
      * Create a new uninitialized instance
@@ -41,14 +40,6 @@ class DirectoryResults implements Results {
      */
     DirectoryResults(String path) {
         this.path = path
-    }
-
-    /**
-     * Create a new instance with the specified path and number of files in the directory
-     */
-    DirectoryResults(String path, int numberOfFilesInThisDirectory) {
-        this.path = path
-        this.numberOfFilesInThisDirectory = numberOfFilesInThisDirectory
     }
 
     /**
@@ -76,7 +67,6 @@ class DirectoryResults implements Results {
         if (getPath() == fileResPath || (getPath() == '' && fileResPath == null)) {
             // Same directory: Add FileResults here
             this.addChild(fileRes)
-            this.numberOfFilesInThisDirectory++
         } else {
             // Find if there is already a child directory result and use it if found
             DirectoryResults subDirResults = (DirectoryResults) findResultsForPath(fileResPath)
@@ -165,11 +155,15 @@ class DirectoryResults implements Results {
      * @return the total number of files (with or without violations)
      */
     int getTotalNumberOfFiles(boolean recursive = true) {
-        def total = numberOfFilesInThisDirectory
-        if (recursive) {
-            total += children.sum(0) { child -> child.isFile() ? 0 : child.getTotalNumberOfFiles(true) }
+        children.sum(0) { child ->
+            if (child.isFile()) {
+                return 1
+            }
+            if (recursive) {
+                return child.getTotalNumberOfFiles(recursive)
+            }
+            return 0
         }
-        total
     }
 
     /**

--- a/src/main/java/org/codenarc/ant/AntFileSetSourceAnalyzer.java
+++ b/src/main/java/org/codenarc/ant/AntFileSetSourceAnalyzer.java
@@ -56,7 +56,6 @@ public class AntFileSetSourceAnalyzer extends AbstractSourceAnalyzer {
 
     // Concurrent shared state
     private final ConcurrentMap<String, List<FileResults>> resultsMap = new ConcurrentHashMap<String, List<FileResults>>();
-    private final ConcurrentMap<String, AtomicInteger> fileCountMap = new ConcurrentHashMap<String, AtomicInteger>();
     private final AtomicLong sourceFileErrors = new AtomicLong(0L);
 
     /**
@@ -193,14 +192,6 @@ public class AntFileSetSourceAnalyzer extends AbstractSourceAnalyzer {
         String parentPath = PathUtil.getParentPath(filePath);
         String safeParentPath = parentPath != null ? parentPath : "";
         addToResultsMap(safeParentPath, fileResults);
-        incrementFileCount(safeParentPath);
-    }
-
-    private void incrementFileCount(String parentPath) {
-        AtomicInteger initialZeroCount = new AtomicInteger(0);
-        fileCountMap.putIfAbsent(parentPath, initialZeroCount);
-        AtomicInteger fileCount = fileCountMap.get(parentPath);
-        fileCount.incrementAndGet();
     }
 
     private void addToResultsMap(String parentPath, FileResults results) {
@@ -244,8 +235,6 @@ public class AntFileSetSourceAnalyzer extends AbstractSourceAnalyzer {
             for (FileResults child : allResults) {
                 dirResults.addChild(child);
             }
-            AtomicInteger cnt = fileCountMap.get(path);
-            dirResults.setNumberOfFilesInThisDirectory(cnt != null ? cnt.get() : 0);
             addToParentResults(reportResults, dirResults);
         }
     }

--- a/src/test/groovy/org/codenarc/report/AbstractCompactTextReportWriterTestCase.groovy
+++ b/src/test/groovy/org/codenarc/report/AbstractCompactTextReportWriterTestCase.groovy
@@ -91,9 +91,9 @@ abstract class AbstractCompactTextReportWriterTestCase extends AbstractReportWri
         reportWriter = createReportWriter()
         reportWriter.getTimestamp = { TIMESTAMP_DATE }
 
-        def srcMainDirResults = new DirectoryResults('src/main', 2)
-        def srcMainDaoDirResults = new DirectoryResults('src/main/dao', 2)
-        def srcTestDirResults = new DirectoryResults('src/test', 0)
+        def srcMainDirResults = new DirectoryResults('src/main')
+        def srcMainDaoDirResults = new DirectoryResults('src/main/dao')
+        def srcTestDirResults = new DirectoryResults('src/test')
         def srcMainFileResults1 = new FileResults('src/main/MyAction.groovy', [VIOLATION1, VIOLATION3, VIOLATION3, VIOLATION1, VIOLATION2])
         def srcMainFileResults2 = new FileResults('src/main/MyCleanAction.groovy', [])
         def fileResultsMainDao1 = new FileResults('src/main/dao/MyDao.groovy', [VIOLATION3])

--- a/src/test/groovy/org/codenarc/report/AbstractHtmlReportWriterTest.groovy
+++ b/src/test/groovy/org/codenarc/report/AbstractHtmlReportWriterTest.groovy
@@ -107,7 +107,7 @@ class AbstractHtmlReportWriterTest extends AbstractTestCase {
         results = new DirectoryResults('')
         assert !reportWriter.isDirectoryContainingFiles(results)
 
-        results.numberOfFilesInThisDirectory = 2
+        results.addChild(new FileResults('', []))
         assert reportWriter.isDirectoryContainingFiles(results)
     }
 

--- a/src/test/groovy/org/codenarc/report/AbstractHtmlReportWriterTestCase.groovy
+++ b/src/test/groovy/org/codenarc/report/AbstractHtmlReportWriterTestCase.groovy
@@ -57,10 +57,10 @@ abstract class AbstractHtmlReportWriterTestCase extends AbstractReportWriterTest
     void setUpAbstractHtmlReportWriterTest() {
         log(new File('.').absolutePath)
 
-        dirResultsMain = new DirectoryResults('src/main', 1)
-        def dirResultsCode = new DirectoryResults('src/main/code', 1)
-        def dirResultsTest = new DirectoryResults('src/main/test', 1)
-        def dirResultsTestSubdirNoViolations = new DirectoryResults('src/main/test/noviolations', 1)
+        dirResultsMain = new DirectoryResults('src/main')
+        def dirResultsCode = new DirectoryResults('src/main/code')
+        def dirResultsTest = new DirectoryResults('src/main/test')
+        def dirResultsTestSubdirNoViolations = new DirectoryResults('src/main/test/noviolations')
         def dirResultsTestSubdirEmpty = new DirectoryResults('src/main/test/empty')
         def fileResults1 = new FileResults('src/main/MyAction.groovy', [VIOLATION1, VIOLATION3, VIOLATION3, VIOLATION1, VIOLATION2])
         def fileResults2 = new FileResults('src/main/code/MyAction2.groovy', [VIOLATION3])

--- a/src/test/groovy/org/codenarc/report/AbstractTextReportWriterTestCase.groovy
+++ b/src/test/groovy/org/codenarc/report/AbstractTextReportWriterTestCase.groovy
@@ -124,9 +124,9 @@ abstract class AbstractTextReportWriterTestCase extends AbstractReportWriterTest
         reportWriter = createReportWriter()
         reportWriter.getTimestamp = { TIMESTAMP_DATE }
 
-        def srcMainDirResults = new DirectoryResults('src/main', 2)
-        def srcMainDaoDirResults = new DirectoryResults('src/main/dao', 2)
-        def srcTestDirResults = new DirectoryResults('src/test', 0)
+        def srcMainDirResults = new DirectoryResults('src/main')
+        def srcMainDaoDirResults = new DirectoryResults('src/main/dao')
+        def srcTestDirResults = new DirectoryResults('src/test')
         def srcMainFileResults1 = new FileResults('src/main/MyAction.groovy', [VIOLATION1, VIOLATION3, VIOLATION3, VIOLATION1, VIOLATION2])
         def srcMainFileResults2 = new FileResults('src/main/MyCleanAction.groovy', [])
         def fileResultsMainDao1 = new FileResults('src/main/dao/MyDao.groovy', [VIOLATION3])

--- a/src/test/groovy/org/codenarc/report/BaselineXmlReportWriterTest.groovy
+++ b/src/test/groovy/org/codenarc/report/BaselineXmlReportWriterTest.groovy
@@ -97,9 +97,9 @@ class BaselineXmlReportWriterTest extends AbstractXmlReportWriterTestCase {
         reportWriter.getTimestamp = { TIMESTAMP_DATE }
 
         def dirResults = new DirectoryResults()
-        def dirResultsMain = new DirectoryResults('src/main', 2)
-        def dirResultsMainDao = new DirectoryResults('src/main/dao', 2)
-        def dirResultsTest = new DirectoryResults('src/test', 0)
+        def dirResultsMain = new DirectoryResults('src/main')
+        def dirResultsMainDao = new DirectoryResults('src/main/dao')
+        def dirResultsTest = new DirectoryResults('src/test')
         def fileResultsMainDao1 = new FileResults('src/main/dao/MyDao.groovy', [VIOLATION3])
         def fileResultsMainDao2 = new FileResults('src/main/dao/MyOtherDao.groovy', [VIOLATION2])
         def fileResultsMyAction = new FileResults('src/main/MyAction.groovy', [VIOLATION1, VIOLATION3, VIOLATION3, VIOLATION1, VIOLATION2])

--- a/src/test/groovy/org/codenarc/report/BaselineXmlReport_IntegrationTest.groovy
+++ b/src/test/groovy/org/codenarc/report/BaselineXmlReport_IntegrationTest.groovy
@@ -99,8 +99,8 @@ class BaselineXmlReport_IntegrationTest extends AbstractTestCase {
 
     @BeforeEach
     void setUp() {
-        def srcMainDirResults = new DirectoryResults('src/main', 1)
-        srcMainDaoDirResults = new DirectoryResults('src/main/dao', 2)
+        def srcMainDirResults = new DirectoryResults('src/main')
+        srcMainDaoDirResults = new DirectoryResults('src/main/dao')
         srcMainDirResults.addChild(srcMainFileResults1)
         srcMainDirResults.addChild(srcMainDaoDirResults)
         srcMainDaoDirResults.addChild(fileResultsMainDao1)

--- a/src/test/groovy/org/codenarc/report/HtmlReportWriterTest.groovy
+++ b/src/test/groovy/org/codenarc/report/HtmlReportWriterTest.groovy
@@ -111,7 +111,6 @@ class HtmlReportWriterTest extends AbstractHtmlReportWriterTestCase {
             """
         def fileResults4 = new FileResults('src/main/MyActionTest.groovy', [VIOLATION4])
         dirResultsMain.addChild(fileResults4)
-        dirResultsMain.numberOfFilesInThisDirectory++
         reportWriter.maxPriority = 4
         assertReportContents(EXPECTED)
     }

--- a/src/test/groovy/org/codenarc/report/IdeTextReportWriterTest.groovy
+++ b/src/test/groovy/org/codenarc/report/IdeTextReportWriterTest.groovy
@@ -80,7 +80,7 @@ File: src/main/dao/MyDao.groovy
 
         final VIOLATION = new Violation(rule:new StubRule(name:'BadStuff', priority:3), lineNumber:null, sourceLine:SOURCE_LINE3, message:MESSAGE3)
         def fileResults = new FileResults('src/main/dao/MyDao.groovy', [VIOLATION])
-        results = new DirectoryResults('src/main/dao', 1)
+        results = new DirectoryResults('src/main/dao')
         results.addChild(fileResults)
 
         reportWriter.writeReport(stringWriter, analysisContext, results)

--- a/src/test/groovy/org/codenarc/report/InlineXmlReportWriterTest.groovy
+++ b/src/test/groovy/org/codenarc/report/InlineXmlReportWriterTest.groovy
@@ -96,9 +96,9 @@ class InlineXmlReportWriterTest extends AbstractXmlReportWriterTestCase {
         reportWriter = new InlineXmlReportWriter(title:TITLE)
         reportWriter.getTimestamp = { TIMESTAMP_DATE }
 
-        def srcMainDirResults = new DirectoryResults('src/main', 2)
-        def srcMainDaoDirResults = new DirectoryResults('src/main/dao', 2)
-        def srcTestDirResults = new DirectoryResults('src/test', 0)
+        def srcMainDirResults = new DirectoryResults('src/main')
+        def srcMainDaoDirResults = new DirectoryResults('src/main/dao')
+        def srcTestDirResults = new DirectoryResults('src/test')
         def srcMainFileResults1 = new FileResults('src/main/MyAction.groovy', [VIOLATION1, VIOLATION3, VIOLATION3, VIOLATION1, VIOLATION2])
         def srcMainFileResults2 = new FileResults('src/main/MyCleanAction.groovy', [])
         def fileResultsMainDao1 = new FileResults('src/main/dao/MyDao.groovy', [VIOLATION3])

--- a/src/test/groovy/org/codenarc/report/JsonReportWriterTest.groovy
+++ b/src/test/groovy/org/codenarc/report/JsonReportWriterTest.groovy
@@ -71,7 +71,7 @@ class JsonReportWriterTest extends AbstractJsonReportWriterTestCase {
                 }
             }
         '''
-        def dirResults = new DirectoryResults('src/main/dao', 1)
+        def dirResults = new DirectoryResults('src/main/dao')
         dirResults.addChild(new FileResults('src/main/dao/MyDao.groovy', [VIOLATION3]))
         def rootResults = new DirectoryResults()
         rootResults.addChild(dirResults)
@@ -122,9 +122,9 @@ class JsonReportWriterTest extends AbstractJsonReportWriterTestCase {
         reportWriter = new JsonReportWriter(title:TITLE)
         reportWriter.getTimestamp = { TIMESTAMP_DATE }
 
-        def srcMainDirResults = new DirectoryResults('src/main', 2)
-        def srcMainDaoDirResults = new DirectoryResults('src/main/dao', 2)
-        def srcTestDirResults = new DirectoryResults('src/test', 0)
+        def srcMainDirResults = new DirectoryResults('src/main')
+        def srcMainDaoDirResults = new DirectoryResults('src/main/dao')
+        def srcTestDirResults = new DirectoryResults('src/test')
         def srcMainFileResults1 = new FileResults('src/main/MyAction.groovy', [VIOLATION1, VIOLATION3, VIOLATION3, VIOLATION1, VIOLATION2])
         def srcMainFileResults2 = new FileResults('src/main/MyCleanAction.groovy', [])
         def fileResultsMainDao1 = new FileResults('src/main/dao/MyDao.groovy', [VIOLATION3])

--- a/src/test/groovy/org/codenarc/report/SortableHtmlReportWriterTest.groovy
+++ b/src/test/groovy/org/codenarc/report/SortableHtmlReportWriterTest.groovy
@@ -93,7 +93,6 @@ class SortableHtmlReportWriterTest extends AbstractHtmlReportWriterTestCase {
 
         def fileResults4 = new FileResults('src/main/MyOtherAction.groovy', [VIOLATION3])
         dirResultsMain.addChild(fileResults4)
-        dirResultsMain.numberOfFilesInThisDirectory++
     }
 
 }

--- a/src/test/groovy/org/codenarc/report/XmlReportWriterTest.groovy
+++ b/src/test/groovy/org/codenarc/report/XmlReportWriterTest.groovy
@@ -105,7 +105,7 @@ class XmlReportWriterTest extends AbstractXmlReportWriterTestCase {
 
             <Package path='' totalFiles='1' filesWithViolations='1' priority1='0' priority2='0' priority3='1'>
         """
-        def dirResults = new DirectoryResults('', 1)
+        def dirResults = new DirectoryResults('')
         dirResults.addChild(new FileResults('src/main/dao/MyDao.groovy', [VIOLATION3]))
         def rootResults = new DirectoryResults()
         rootResults.addChild(dirResults)
@@ -156,9 +156,9 @@ class XmlReportWriterTest extends AbstractXmlReportWriterTestCase {
         reportWriter = new XmlReportWriter(title:TITLE)
         reportWriter.getTimestamp = { TIMESTAMP_DATE }
 
-        def srcMainDirResults = new DirectoryResults('src/main', 2)
-        def srcMainDaoDirResults = new DirectoryResults('src/main/dao', 2)
-        def srcTestDirResults = new DirectoryResults('src/test', 0)
+        def srcMainDirResults = new DirectoryResults('src/main')
+        def srcMainDaoDirResults = new DirectoryResults('src/main/dao')
+        def srcTestDirResults = new DirectoryResults('src/test')
         def srcMainFileResults1 = new FileResults('src/main/MyAction.groovy', [VIOLATION1, VIOLATION3, VIOLATION3, VIOLATION1, VIOLATION2])
         def srcMainFileResults2 = new FileResults('src/main/MyCleanAction.groovy', [])
         def fileResultsMainDao1 = new FileResults('src/main/dao/MyDao.groovy', [VIOLATION3])

--- a/src/test/groovy/org/codenarc/results/DirectoryResultsTest.groovy
+++ b/src/test/groovy/org/codenarc/results/DirectoryResultsTest.groovy
@@ -57,7 +57,6 @@ class DirectoryResultsTest extends AbstractTestCase {
         assert results.path == PATH
         def fileResults = new FileResults('path', [VIOLATION1, VIOLATION3, VIOLATION3, VIOLATION1, VIOLATION2])
         results.addChild(fileResults)
-        results.numberOfFilesInThisDirectory = 7
         assert results.children == [fileResults]
         assert results.violations.findAll { v -> v.rule.priority == 1 } == [VIOLATION1, VIOLATION1]
         assert results.violations.findAll { v -> v.rule.priority == 2 } == [VIOLATION2]
@@ -71,19 +70,17 @@ class DirectoryResultsTest extends AbstractTestCase {
         assert results.getNumberOfFilesWithViolations(1) == 1
         assert results.getNumberOfFilesWithViolations(1, false) == 1
 
-        assert results.getTotalNumberOfFiles() == 7
-        assert results.getTotalNumberOfFiles(false) == 7
+        assert results.getTotalNumberOfFiles() == 1
+        assert results.getTotalNumberOfFiles(false) == 1
     }
 
     @Test
     void testWithMultipleChildren() {
         def results = new DirectoryResults(PATH)
         assert results.path == PATH
-        results.numberOfFilesInThisDirectory = 3
         def fileResults1 = new FileResults('path', [VIOLATION1, VIOLATION3, VIOLATION3, VIOLATION7, VIOLATION1, VIOLATION2])
         results.addChild(fileResults1)
         def subDirResults = new DirectoryResults('subdir')
-        subDirResults.numberOfFilesInThisDirectory = 2
         def fileResults2 = new FileResults('path', [VIOLATION2, VIOLATION3, VIOLATION4])
         subDirResults.addChild(fileResults2)
         results.addChild(subDirResults)
@@ -111,8 +108,8 @@ class DirectoryResultsTest extends AbstractTestCase {
         assert results.getNumberOfFilesWithViolations(1, false) == 1
         assert subDirResults.getNumberOfFilesWithViolations(1, false) == 0
 
-        assert results.getTotalNumberOfFiles() == 5
-        assert results.getTotalNumberOfFiles(false) == 3
+        assert results.getTotalNumberOfFiles() == 2
+        assert results.getTotalNumberOfFiles(false) == 1
     }
 
     @Test


### PR DESCRIPTION
This one is based on #694 and already presented as a draft here. There are two main elements to this, maintaining a file count in `DirectoryResults` and handling of files without violations. Actually, I could even split this PR at their border, if desirable.

The handling of the file count in `DirectoryResults` is the easier part of the two. Instead of having a member variable, just look at the list of children. The rest is just to remove code that initialized or modified the count. Actually, the hard work was sorting the cases where this changed the results for the tests into those where the tests themselves where wrong and cases where the code was actually wrong.

The other part is the handling of files without violations. There was some special code inside the two classes `FilesystemSourceAnalyzer` and `AntFileSetSourceAnalyzer` that stripped files without violations from the results, but only partially. I've removed that code, so that even files without violations are included now. If and where a report doesn't want is now implemented there.