### PR TITLE
UnusedImportRule: detect property-style usage of static imports

### DIFF
--- a/src/test/groovy/org/codenarc/rule/imports/UnusedImportRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/imports/UnusedImportRuleTest.groovy
@@ -159,6 +159,27 @@ class UnusedImportRuleTest extends AbstractRuleTestCase<UnusedImportRule> {
     }
 
     @Test
+    void testApplyTo_StaticImportWithPropertyUsage() {
+        final SOURCE = '''
+            import static System.getProperties
+            import static a.SomeClass.isEnabled
+            import static b.OtherClass.setInstance
+            class ABC {
+                def foo() {
+                    properties.getProperty("foo")
+                }
+                def bar() {
+                    if (enabled) {
+                        instance = this
+                    }
+                }
+            }
+        '''
+        // The static import is used as property style, so no violation
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
     void testApplyTo_NoViolations() {
         final SOURCE = '''
             import java.io.InputStream


### PR DESCRIPTION
Prior to this commit, UnusedImportRule didn't detect usage of static imports of getter/setter-style methods
when written as properties.

fixes #698 