### PR TITLE
Feature/handling files without violations

### DIFF
--- a/src/main/groovy/org/codenarc/analyzer/FilesystemSourceAnalyzer.groovy
+++ b/src/main/groovy/org/codenarc/analyzer/FilesystemSourceAnalyzer.groovy
@@ -97,7 +97,7 @@ class FilesystemSourceAnalyzer extends AbstractSourceAnalyzer {
     @SuppressWarnings(['CatchThrowable', 'NestedBlockDepth'])
     private DirectoryResults processDirectory(String dir, RuleSet ruleSet) {
         def dirResults = new DirectoryResults(dir)
-        def dirFile = new File((String) baseDirectory, (String) dir)
+        def dirFile = new File(baseDirectory, dir)
         dirFile.eachFile { file ->
             def dirPrefix = dir ? dir + SEP : dir
             def filePath = dirPrefix + file.name
@@ -123,15 +123,13 @@ class FilesystemSourceAnalyzer extends AbstractSourceAnalyzer {
     }
 
     private void processFile(String filePath, DirectoryResults dirResults, RuleSet ruleSet) {
-        def file = new File((String) baseDirectory, filePath)
+        def file = new File(baseDirectory, filePath)
         def sourceFile = new SourceFile(file)
         if (matches(sourceFile)) {
-            dirResults.numberOfFilesInThisDirectory++
             List allViolations = collectViolations(sourceFile, ruleSet)
-            if (allViolations) {
-                def fileResults = new FileResults(filePath, allViolations, sourceFile)
-                dirResults.addChild(fileResults)
-            }
+            def fileResults = new FileResults(filePath, allViolations, sourceFile)
+            dirResults.numberOfFilesInThisDirectory++
+            dirResults.addChild(fileResults)
         }
     }
 

--- a/src/main/groovy/org/codenarc/report/BaselineXmlReportWriter.groovy
+++ b/src/main/groovy/org/codenarc/report/BaselineXmlReportWriter.groovy
@@ -88,7 +88,9 @@ class BaselineXmlReportWriter extends AbstractReportWriter {
         }
 
         return {
-            children.each { child ->
+            children.findAll { child ->
+                !child.violations.isEmpty()
+            }.each { child ->
                 out << buildFileElement(child)
             }
         }

--- a/src/main/groovy/org/codenarc/report/XmlReportWriter.groovy
+++ b/src/main/groovy/org/codenarc/report/XmlReportWriter.groovy
@@ -77,10 +77,10 @@ class XmlReportWriter extends AbstractReportWriter {
         def elementName = isRoot(results) ? 'PackageSummary' : 'Package'
         return {
             "$elementName"(buildPackageAttributeMap(results)) {
-                results.children.each { child ->
-                    if (child.isFile()) {
-                        out << buildFileElement(child)
-                    }
+                results.children.findAll { child ->
+                    child.isFile() && !child.violations.isEmpty()
+                }.each { child ->
+                    out << buildFileElement(child)
                 }
             }
             results.children.each { child ->

--- a/src/main/java/org/codenarc/ant/AntFileSetSourceAnalyzer.java
+++ b/src/main/java/org/codenarc/ant/AntFileSetSourceAnalyzer.java
@@ -189,10 +189,7 @@ public class AntFileSetSourceAnalyzer extends AbstractSourceAnalyzer {
         if (!sourceFile.isValid()) {
             sourceFileErrors.incrementAndGet();
         }
-        FileResults fileResults = null;
-        if (allViolations != null && !allViolations.isEmpty()) {
-            fileResults = new FileResults(PathUtil.normalizePath(filePath), allViolations, sourceFile);
-        }
+        FileResults fileResults = new FileResults(PathUtil.normalizePath(filePath), allViolations, sourceFile);
         String parentPath = PathUtil.getParentPath(filePath);
         String safeParentPath = parentPath != null ? parentPath : "";
         addToResultsMap(safeParentPath, fileResults);

--- a/src/test/groovy/org/codenarc/analyzer/FilesystemSourceAnalyzerTest.groovy
+++ b/src/test/groovy/org/codenarc/analyzer/FilesystemSourceAnalyzerTest.groovy
@@ -114,7 +114,7 @@ class FilesystemSourceAnalyzerTest extends AbstractTestCase {
         log("results=$results")
 
         def paths = resultsPaths(results)
-        assertEqualSets(paths, ['subdir1', 'subdir2', 'subdir2/subdir2a'])
+        assertEqualSets(paths, ['SourceFile1.groovy', 'subdir1', 'subdir1/Subdir1File2.groovy', 'subdir1/Subdir1File1.groovy', 'subdir2', 'subdir2/subdir2a', 'subdir2/subdir2a/Subdir2aFile1.groovy', 'subdir2/Subdir2File1.groovy'])
 
         assert testCountRule.count == 5
         assert results.getNumberOfFilesWithViolations(3) == 0
@@ -128,7 +128,7 @@ class FilesystemSourceAnalyzerTest extends AbstractTestCase {
 
         analyzer.baseDirectory = BASE_DIR
         def results = analyzer.analyze(ruleSet)
-        assert results.totalNumberOfFiles == 5
+        assert results.totalNumberOfFiles == 0
     }
 
     @Test

--- a/src/test/groovy/org/codenarc/ant/AntFileSetSourceAnalyzerTest.groovy
+++ b/src/test/groovy/org/codenarc/ant/AntFileSetSourceAnalyzerTest.groovy
@@ -151,7 +151,7 @@ class AntFileSetSourceAnalyzerTest extends AbstractTestCase {
         log(results)
         assertResultsCounts(results, 2, 0)
 
-        assert getAllResultsPaths(results) == ['sourcewitherrors']
+        assert getAllResultsPaths(results) == ['sourcewitherrors', 'sourcewitherrors/SourceFile1.txt', 'sourcewitherrors/SourceFileWithCompileError.txt']
     }
 
     @Test

--- a/src/test/groovy/org/codenarc/report/AbstractCompactTextReportWriterTestCase.groovy
+++ b/src/test/groovy/org/codenarc/report/AbstractCompactTextReportWriterTestCase.groovy
@@ -100,14 +100,16 @@ abstract class AbstractCompactTextReportWriterTestCase extends AbstractTestCase 
         reportWriter = createReportWriter()
         reportWriter.getTimestamp = { TIMESTAMP_DATE }
 
-        def srcMainDirResults = new DirectoryResults('src/main', 1)
+        def srcMainDirResults = new DirectoryResults('src/main', 2)
         def srcMainDaoDirResults = new DirectoryResults('src/main/dao', 2)
         def srcTestDirResults = new DirectoryResults('src/test', 0)
         def srcMainFileResults1 = new FileResults('src/main/MyAction.groovy', [VIOLATION1, VIOLATION3, VIOLATION3, VIOLATION1, VIOLATION2])
+        def srcMainFileResults2 = new FileResults('src/main/MyCleanAction.groovy', [])
         def fileResultsMainDao1 = new FileResults('src/main/dao/MyDao.groovy', [VIOLATION3])
         def fileResultsMainDao2 = new FileResults('src/main/dao/MyOtherDao.groovy', [VIOLATION2, VIOLATION1])
 
         srcMainDirResults.addChild(srcMainFileResults1)
+        srcMainDirResults.addChild(srcMainFileResults2)
         srcMainDirResults.addChild(srcMainDaoDirResults)
         srcMainDaoDirResults.addChild(fileResultsMainDao1)
         srcMainDaoDirResults.addChild(fileResultsMainDao2)

--- a/src/test/groovy/org/codenarc/report/AbstractTextReportWriterTestCase.groovy
+++ b/src/test/groovy/org/codenarc/report/AbstractTextReportWriterTestCase.groovy
@@ -147,14 +147,16 @@ abstract class AbstractTextReportWriterTestCase extends AbstractTestCase {
         reportWriter = createReportWriter()
         reportWriter.getTimestamp = { TIMESTAMP_DATE }
 
-        def srcMainDirResults = new DirectoryResults('src/main', 1)
+        def srcMainDirResults = new DirectoryResults('src/main', 2)
         def srcMainDaoDirResults = new DirectoryResults('src/main/dao', 2)
         def srcTestDirResults = new DirectoryResults('src/test', 0)
         def srcMainFileResults1 = new FileResults('src/main/MyAction.groovy', [VIOLATION1, VIOLATION3, VIOLATION3, VIOLATION1, VIOLATION2])
+        def srcMainFileResults2 = new FileResults('src/main/MyCleanAction.groovy', [])
         def fileResultsMainDao1 = new FileResults('src/main/dao/MyDao.groovy', [VIOLATION3])
         def fileResultsMainDao2 = new FileResults('src/main/dao/MyOtherDao.groovy', [VIOLATION2, VIOLATION1])
 
         srcMainDirResults.addChild(srcMainFileResults1)
+        srcMainDirResults.addChild(srcMainFileResults2)
         srcMainDirResults.addChild(srcMainDaoDirResults)
         srcMainDaoDirResults.addChild(fileResultsMainDao1)
         srcMainDaoDirResults.addChild(fileResultsMainDao2)

--- a/src/test/groovy/org/codenarc/report/BaselineXmlReportWriterTest.groovy
+++ b/src/test/groovy/org/codenarc/report/BaselineXmlReportWriterTest.groovy
@@ -101,18 +101,20 @@ class BaselineXmlReportWriterTest extends AbstractXmlReportWriterTestCase {
         reportWriter.getTimestamp = { TIMESTAMP_DATE }
 
         def dirResults = new DirectoryResults()
-        def dirResultsMain = new DirectoryResults('src/main', 1)
+        def dirResultsMain = new DirectoryResults('src/main', 2)
         def dirResultsMainDao = new DirectoryResults('src/main/dao', 2)
         def dirResultsTest = new DirectoryResults('src/test', 0)
         def fileResultsMainDao1 = new FileResults('src/main/dao/MyDao.groovy', [VIOLATION3])
         def fileResultsMainDao2 = new FileResults('src/main/dao/MyOtherDao.groovy', [VIOLATION2])
         def fileResultsMyAction = new FileResults('src/main/MyAction.groovy', [VIOLATION1, VIOLATION3, VIOLATION3, VIOLATION1, VIOLATION2])
+        def fileResultsMyCleanAction = new FileResults('src/main/MyCleanAction.groovy', [])
 
         // assemble results
         // The order here is not alphabetically, because directory scanning
         // isn't either, but the baseline report has to sort the data, which
         // is done via the comparison with the report XML above.
         dirResultsMain.addChild(fileResultsMyAction)
+        dirResultsMain.addChild(fileResultsMyCleanAction)
         dirResultsMain.addChild(dirResultsMainDao)
         dirResultsMainDao.addChild(fileResultsMainDao2)
         dirResultsMainDao.addChild(fileResultsMainDao1)

--- a/src/test/groovy/org/codenarc/report/IdeTextReportWriterTest.groovy
+++ b/src/test/groovy/org/codenarc/report/IdeTextReportWriterTest.groovy
@@ -31,7 +31,7 @@ class IdeTextReportWriterTest extends AbstractTextReportWriterTestCase {
     private static final REPORT_TEXT = """
 CodeNarc Report: My Cool Project - ${formattedTimestamp()}
 
-Summary: TotalFiles=3 FilesWithViolations=3 P1=3 P2=2 P3=3
+Summary: TotalFiles=4 FilesWithViolations=3 P1=3 P2=2 P3=3
 
 File: src/main/MyAction.groovy
     Violation: Rule=Rule1 P=1 Loc=.(MyAction.groovy:11) Src=[if (count < 23 && index <= 99) {]
@@ -52,7 +52,7 @@ File: src/main/dao/MyOtherDao.groovy
     private static final REPORT_TEXT_MAX_PRIORITY = """
 CodeNarc Report: My Cool Project - ${formattedTimestamp()}
 
-Summary: TotalFiles=3 FilesWithViolations=2 P1=3
+Summary: TotalFiles=4 FilesWithViolations=2 P1=3
 
 File: src/main/MyAction.groovy
     Violation: Rule=Rule1 P=1 Loc=.(MyAction.groovy:11) Src=[if (count < 23 && index <= 99) {]

--- a/src/test/groovy/org/codenarc/report/InlineXmlReportWriterTest.groovy
+++ b/src/test/groovy/org/codenarc/report/InlineXmlReportWriterTest.groovy
@@ -39,10 +39,10 @@ class InlineXmlReportWriterTest extends AbstractXmlReportWriterTestCase {
             <SourceDirectory>c:/MyProject/src/test/groovy</SourceDirectory>
         </Project>
 
-        <PackageSummary totalFiles='3' filesWithViolations='3' priority1='0' priority2='5' priority3='2'>
+        <PackageSummary totalFiles='4' filesWithViolations='3' priority1='0' priority2='5' priority3='2'>
         </PackageSummary>
 
-        <Package path='src/main' totalFiles='3' filesWithViolations='3' priority1='0' priority2='5' priority3='2'>
+        <Package path='src/main' totalFiles='4' filesWithViolations='3' priority1='0' priority2='5' priority3='2'>
             <File name='MyAction.groovy'>
                 <Violation ruleName='UnusedImport' priority='3' lineNumber='111'>
                     <SourceLine><![CDATA[if (count &lt; 23 &amp;&amp; index &lt;= 99 &amp;&amp; name.contains('')) {]]></SourceLine>
@@ -102,14 +102,16 @@ class InlineXmlReportWriterTest extends AbstractXmlReportWriterTestCase {
         reportWriter = new InlineXmlReportWriter(title:TITLE)
         reportWriter.getTimestamp = { TIMESTAMP_DATE }
 
-        def srcMainDirResults = new DirectoryResults('src/main', 1)
+        def srcMainDirResults = new DirectoryResults('src/main', 2)
         def srcMainDaoDirResults = new DirectoryResults('src/main/dao', 2)
         def srcTestDirResults = new DirectoryResults('src/test', 0)
         def srcMainFileResults1 = new FileResults('src/main/MyAction.groovy', [VIOLATION1, VIOLATION3, VIOLATION3, VIOLATION1, VIOLATION2])
+        def srcMainFileResults2 = new FileResults('src/main/MyCleanAction.groovy', [])
         def fileResultsMainDao1 = new FileResults('src/main/dao/MyDao.groovy', [VIOLATION3])
         def fileResultsMainDao2 = new FileResults('src/main/dao/MyOtherDao.groovy', [VIOLATION2])
 
         srcMainDirResults.addChild(srcMainFileResults1)
+        srcMainDirResults.addChild(srcMainFileResults2)
         srcMainDirResults.addChild(srcMainDaoDirResults)
         srcMainDaoDirResults.addChild(fileResultsMainDao1)
         srcMainDaoDirResults.addChild(fileResultsMainDao2)

--- a/src/test/groovy/org/codenarc/report/JsonReportWriterTest.groovy
+++ b/src/test/groovy/org/codenarc/report/JsonReportWriterTest.groovy
@@ -127,14 +127,16 @@ class JsonReportWriterTest extends AbstractJsonReportWriterTestCase {
         reportWriter = new JsonReportWriter(title:TITLE)
         reportWriter.getTimestamp = { TIMESTAMP_DATE }
 
-        def srcMainDirResults = new DirectoryResults('src/main', 1)
+        def srcMainDirResults = new DirectoryResults('src/main', 2)
         def srcMainDaoDirResults = new DirectoryResults('src/main/dao', 2)
         def srcTestDirResults = new DirectoryResults('src/test', 0)
         def srcMainFileResults1 = new FileResults('src/main/MyAction.groovy', [VIOLATION1, VIOLATION3, VIOLATION3, VIOLATION1, VIOLATION2])
+        def srcMainFileResults2 = new FileResults('src/main/MyCleanAction.groovy', [])
         def fileResultsMainDao1 = new FileResults('src/main/dao/MyDao.groovy', [VIOLATION3])
         def fileResultsMainDao2 = new FileResults('src/main/dao/MyOtherDao.groovy', [VIOLATION2])
 
         srcMainDirResults.addChild(srcMainFileResults1)
+        srcMainDirResults.addChild(srcMainFileResults2)
         srcMainDirResults.addChild(srcMainDaoDirResults)
         srcMainDaoDirResults.addChild(fileResultsMainDao1)
         srcMainDaoDirResults.addChild(fileResultsMainDao2)

--- a/src/test/groovy/org/codenarc/report/TextReportWriterTest.groovy
+++ b/src/test/groovy/org/codenarc/report/TextReportWriterTest.groovy
@@ -26,7 +26,7 @@ class TextReportWriterTest extends AbstractTextReportWriterTestCase {
     private static final REPORT_TEXT = """
 CodeNarc Report: My Cool Project - ${formattedTimestamp()}
 
-Summary: TotalFiles=3 FilesWithViolations=3 P1=3 P2=2 P3=3
+Summary: TotalFiles=4 FilesWithViolations=3 P1=3 P2=2 P3=3
 
 File: src/main/MyAction.groovy
     Violation: Rule=Rule1 P=1 Line=11 Src=[if (count < 23 && index <= 99) {]
@@ -47,7 +47,7 @@ File: src/main/dao/MyOtherDao.groovy
     private static final REPORT_TEXT_MAX_PRIORITY = """
 CodeNarc Report: My Cool Project - ${formattedTimestamp()}
 
-Summary: TotalFiles=3 FilesWithViolations=2 P1=3
+Summary: TotalFiles=4 FilesWithViolations=2 P1=3
 
 File: src/main/MyAction.groovy
     Violation: Rule=Rule1 P=1 Line=11 Src=[if (count < 23 && index <= 99) {]

--- a/src/test/groovy/org/codenarc/report/XmlReportWriterTest.groovy
+++ b/src/test/groovy/org/codenarc/report/XmlReportWriterTest.groovy
@@ -51,10 +51,10 @@ class XmlReportWriterTest extends AbstractXmlReportWriterTestCase {
             <SourceDirectory>c:/MyProject/src/test/groovy</SourceDirectory>
         </Project>
 
-        <PackageSummary totalFiles='3' filesWithViolations='3' priority1='2' priority2='2' priority3='3'>
+        <PackageSummary totalFiles='4' filesWithViolations='3' priority1='2' priority2='2' priority3='3'>
         </PackageSummary>
 
-        <Package path='src/main' totalFiles='3' filesWithViolations='3' priority1='2' priority2='2' priority3='3'>
+        <Package path='src/main' totalFiles='4' filesWithViolations='3' priority1='2' priority2='2' priority3='3'>
             <File name='MyAction.groovy'>
                 <Violation ruleName='RULE1' priority='1' lineNumber='111'>
                     <SourceLine><![CDATA[if (count &lt; 23 &amp;&amp; index &lt;= 99 &amp;&amp; name.contains('')) {]]></SourceLine>
@@ -169,14 +169,16 @@ class XmlReportWriterTest extends AbstractXmlReportWriterTestCase {
         reportWriter = new XmlReportWriter(title:TITLE)
         reportWriter.getTimestamp = { TIMESTAMP_DATE }
 
-        def srcMainDirResults = new DirectoryResults('src/main', 1)
+        def srcMainDirResults = new DirectoryResults('src/main', 2)
         def srcMainDaoDirResults = new DirectoryResults('src/main/dao', 2)
         def srcTestDirResults = new DirectoryResults('src/test', 0)
         def srcMainFileResults1 = new FileResults('src/main/MyAction.groovy', [VIOLATION1, VIOLATION3, VIOLATION3, VIOLATION1, VIOLATION2])
+        def srcMainFileResults2 = new FileResults('src/main/MyCleanAction.groovy', [])
         def fileResultsMainDao1 = new FileResults('src/main/dao/MyDao.groovy', [VIOLATION3])
         def fileResultsMainDao2 = new FileResults('src/main/dao/MyOtherDao.groovy', [VIOLATION2])
 
         srcMainDirResults.addChild(srcMainFileResults1)
+        srcMainDirResults.addChild(srcMainFileResults2)
         srcMainDirResults.addChild(srcMainDaoDirResults)
         srcMainDaoDirResults.addChild(fileResultsMainDao1)
         srcMainDaoDirResults.addChild(fileResultsMainDao2)


### PR DESCRIPTION
This makes sure that at the analyzer level, files are treated regardless of whether they contain violations or not. Instead, when generating a report from the analyzer results, skip those files.

Also, add a file without violations to most tests, just to ensure correct behaviour. BTW: Here's one thing that could be worth refactoring: All different report generator tests have their own set of analyzer results they operate on. Replacing that with a centrally managed set of analyzer results would make test maintenance a bit more convenient. Also, if you add example data for _one_ corner case, you'd know that you have it covered for _all_ report generators.

I extracted this part from #695, which was too big to realistically review.