### PR TITLE
SpaceBeforeOpeningBraceRule and SpaceAfterOpeningBraceRule fail when …

### DIFF
--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterOpeningBraceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceAfterOpeningBraceRuleTest.groovy
@@ -50,7 +50,10 @@ class SpaceAfterOpeningBraceRuleTest extends AbstractRuleTestCase<SpaceAfterOpen
                     for(String name: names) { }
                     if (count > this."maxPriority${priority}Violations") { }
                     while (count > this."maxPriority${priority}Violations") { }
+                    poo("with an emoji 💩 should not break") { }
+                    poo("with unicode 𝓈 should not break") { }
                 }
+                def poo(String message, Closure cls) { }
                 MyClass() {
                     this(classNames)
                 }

--- a/src/test/groovy/org/codenarc/rule/formatting/SpaceBeforeOpeningBraceRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/SpaceBeforeOpeningBraceRuleTest.groovy
@@ -49,7 +49,10 @@ class SpaceBeforeOpeningBraceRuleTest extends AbstractRuleTestCase<SpaceBeforeOp
                     for(String name: names) { }
                     if (count > this."maxPriority${priority}Violations") { }
                     while (count > this."maxPriority${priority}Violations") { }
+                    poo("with an emoji 💩 should not break") { }
+                    poo("with unicode 𝓈 should not break") { }
                 }
+                def poo(String message, Closure cls) { }
                 MyClass() {
                     this(classNames)
                 }


### PR DESCRIPTION
higher unicode characters are used on the same line.

This PR provides a reproducer for this issue.