### PR TITLE
Remove CodeNarc Eclipse plugin reference

### DIFF
--- a/docs/codenarc-other-tools-frameworks.md
+++ b/docs/codenarc-other-tools-frameworks.md
@@ -9,8 +9,6 @@ title: CodeNarc - Integration with Other Tools / Frameworks
 
   * [IntelliJ IDEA](http://www.jetbrains.com/idea/) - See the [IDEA CodeNarc Plugin](http://plugins.jetbrains.com/plugin/?idea&id=5925).
 
-  * [Eclipse](http://eclipse.org/) - See the [Eclipse CodeNarc Plugin](http://codenarceclipse.sourceforge.net/).
-
   * [Visual Studio Code](https://code.visualstudio.com/) - See the [VsCode Groovy Lint extension](https://marketplace.visualstudio.com/items?itemName=NicolasVuillamy.vscode-groovy-lint).
 
 ## Docker


### PR DESCRIPTION
The plugin has been discontinued and removed from the Eclipse Marketplace on 2022-11-01.