### PR TITLE
Fix ClassStartsWithBlankLine for interfaces, enums and traits with annotations

### DIFF
--- a/src/main/java/org/codenarc/util/AstUtil.java
+++ b/src/main/java/org/codenarc/util/AstUtil.java
@@ -1097,9 +1097,9 @@ public class AstUtil {
             List<AnnotationNode> annotations = ((AnnotatedNode) node).getAnnotations();
             AnnotationNode lastAnnotation = annotations.get(annotations.size() - 1);
 
-            String rawLine = getRawLine(sourceCode, lastAnnotation.getLastLineNumber()-1);
+            String rawLine = getRawLine(sourceCode, lastAnnotation.getLastLineNumber() - 1);
 
-            if(rawLine == null) {
+            if (rawLine == null) {
                 return node.getLineNumber();
             }
 
@@ -1113,7 +1113,7 @@ public class AstUtil {
                 }
 
                 if (node.getClass() == ClassNode.class) {
-                    if (rawLine.contains("class")) {
+                    if (rawLine.contains("class") || rawLine.contains("interface") || rawLine.contains("enum") || rawLine.contains("trait")) {
                         return lastAnnotation.getLastLineNumber();
                     }
                     // Otherwise, fall through to use the next line

--- a/src/test/groovy/org/codenarc/rule/formatting/ClassStartsWithBlankLineRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/formatting/ClassStartsWithBlankLineRuleTest.groovy
@@ -69,6 +69,50 @@ class ClassStartsWithBlankLineRuleTest extends AbstractRuleTestCase<ClassStartsW
     }
 
     @Test
+    void test_EnumWithAnnotation_BlankLineIsRequired() {
+        final String SOURCE = '''
+            import groovy.transform.CompileStatic
+            
+            @CompileStatic enum Foo {
+
+                BAR, BAZ, BLAH
+            }
+        '''
+        rule.blankLineRequired = true
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void test_InterfaceWithAnnotation_BlankLineIsRequired() {
+        final String SOURCE = '''
+            import groovy.transform.CompileStatic
+            
+            @CompileStatic interface Foo {
+
+                int getFoo()
+            }
+        '''
+        rule.blankLineRequired = true
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void test_TraitWithAnnotation_BlankLineIsRequired() {
+        final String SOURCE = '''
+            import groovy.transform.CompileStatic
+            
+            @CompileStatic trait Foo {
+
+                int getFoo() {
+                    0
+                }
+            }
+        '''
+        rule.blankLineRequired = true
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
     void test_BlankLineIsNotRequired() {
         final String SOURCE = '''
             class Foo {


### PR DESCRIPTION
The `ClassStartsWithBlankLine` rule was failing when interfaces, traits or enum were defined with annotations _on same line_ as the declaration

This fixes #750