### PR TITLE
fix: exact path patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ src/main/java/META-INF/
 /classes
 /out
 /integration-test/out/test/classes
+bin/

--- a/src/main/groovy/org/codenarc/analyzer/FilesystemSourceAnalyzer.groovy
+++ b/src/main/groovy/org/codenarc/analyzer/FilesystemSourceAnalyzer.groovy
@@ -125,7 +125,8 @@ class FilesystemSourceAnalyzer extends AbstractSourceAnalyzer {
     private void processFile(String filePath, DirectoryResults dirResults, RuleSet ruleSet) {
         def file = new File(baseDirectory, filePath)
         def sourceFile = new SourceFile(file)
-        if (matches(sourceFile)) {
+        // Match on the filePath only to allow for exact relative paths.
+        if (matches(new SourceFile(new File(filePath)))) {
             List allViolations = collectViolations(sourceFile, ruleSet)
             def fileResults = new FileResults(filePath, allViolations, sourceFile)
             dirResults.numberOfFilesInThisDirectory++

--- a/src/main/groovy/org/codenarc/util/WildcardPattern.groovy
+++ b/src/main/groovy/org/codenarc/util/WildcardPattern.groovy
@@ -97,13 +97,24 @@ class WildcardPattern {
         assert stringWithWildcards != null
 
         def result = new StringBuffer()
-        def prevCharWasStar = false
-        stringWithWildcards.each { ch ->
+        def last = stringWithWildcards.size() - 1
+        for (int i = 0; i <= last; i++) {
+            def ch = stringWithWildcards[i]
             switch (ch) {
                 case '*':
-                    // Single '*' matches single dir/file; Double '*' matches sequence of zero or more dirs/files
-                    result << (prevCharWasStar ? /.*/ : /[^\/]*/)
-                    prevCharWasStar = !prevCharWasStar
+                    if (i < last && stringWithWildcards[i + 1] != '*') {
+                        // Single '*' matches single dir/file
+                        result << /[^\/]*/
+                        break
+                    }
+
+                    // Double '*' matches sequence of zero or more dirs/files
+                    result << '.*'
+                    i++
+                    if (i < last && stringWithWildcards[i + 1] == '/') {
+                        // Ignore slash after '**' as per ant / glob
+                        i++
+                    }
                     break
                 case '?':
                     // Any character except the normalized file separator ('/')
@@ -112,7 +123,9 @@ class WildcardPattern {
                 case ['$', '|', '[', ']', '(', ')', '.', ':', '{', '}', '\\', '^', '+']:
                     result << '\\' + ch
                     break
-                default: result << ch
+                default:
+                    result << ch
+                    break
             }
         }
         result

--- a/src/test/groovy/org/codenarc/analyzer/FilesystemSourceAnalyzerTest.groovy
+++ b/src/test/groovy/org/codenarc/analyzer/FilesystemSourceAnalyzerTest.groovy
@@ -174,6 +174,25 @@ class FilesystemSourceAnalyzerTest extends AbstractTestCase {
     }
 
     @Test
+    void test_analyze_IncludesExactRelative() {
+        analyzer.baseDirectory = BASE_DIR
+        analyzer.includes = 'subdir2/*.groovy'
+
+        def results = analyzer.analyze(ruleSet)
+        log("results=$results")
+
+        def fullPaths = results.violations*.message
+        assert fullPaths.containsAll([
+            'src/test/resources/sourcewithdirs/subdir2/Subdir2File1.groovy'
+        ])
+        assert fullPaths.size() == 1
+
+        assert testCountRule.count == 1
+        assert results.getNumberOfFilesWithViolations(1) == 1
+        assert results.totalNumberOfFiles == 1
+    }
+
+    @Test
     void test_analyze_failOnError_True_RuleThrowsException() {
         def rule = new StubRule(applyToClosure:{ sourceCode, violations -> throw new Exception() })
         ruleSet = new ListRuleSet([rule])

--- a/src/test/groovy/org/codenarc/test/TestUtil.groovy
+++ b/src/test/groovy/org/codenarc/test/TestUtil.groovy
@@ -122,7 +122,7 @@ class TestUtil {
      * the two collections are the same, ignoring ordering and duplicates.
      */
     static void assertEqualSets(Collection collection1, Collection collection2) {
-        assert collection1 as Set == collection2 as Set
+        assert collection1 as Set == collection2 as Set, "sets are not equal $collection1 != $collection2"
     }
 
     /**


### PR DESCRIPTION
Fix processing of exact path patterns by matching the pattern against the file path (relative path), not the absolute path with basedir prepended (absolute path)

This allows users to specify exact paths within patterns, for example:
```text
-include=subdir/*.groovy
-basedir=/home/myuser
```

Will now correctly match the file:
```text
/home/myuser/subdir/*.groovy
```
This changes the behaviour of pattern matches to ignore a forward slash directly after a double star, for example:` **/*.groovy` so that it will match files in the directory or sub directories instead of just sub directories, matching the behaviour of ant / globstar.

Also:
* Add bin/ to .gitignore so output files aren't available for commit.
* Add helpful message on assert failure of equal sets.

Fixes #752