### PR TITLE
Add ignore options to method order rules

### DIFF
--- a/docs/codenarc-rules-convention.md
+++ b/docs/codenarc-rules-convention.md
@@ -474,6 +474,10 @@ Example of violations:
 
 Enforce that all public methods are above protected and private methods.
 
+| Property                    | Description            | Default Value    |
+|-----------------------------|------------------------|------------------|
+| ignoreMethodNames           | Specifies one or more (comma-separated) non-public method names that should be ignored (i.e., that should not cause a rule violation). The names may optionally contain wildcards (*,?).  | `null`  |
+
 Example of violations:
 
 ```
@@ -521,6 +525,10 @@ Enforce that all static methods within each visibility level (public, protected,
 instance methods within that same visibility level. In other words, public static methods must be above
 public instance methods, protected static methods must be above protected instance methods and private
 static methods must be above private instance methods.
+
+| Property                    | Description            | Default Value    |
+|-----------------------------|------------------------|------------------|
+| ignoreMethodNames           | Specifies one or more (comma-separated) instance method names that should be ignored (i.e., that should not cause a rule violation). The names may optionally contain wildcards (*,?).  | `null`  |
 
 Example of violations:
 

--- a/src/main/groovy/org/codenarc/rule/convention/PublicMethodsBeforeNonPublicMethodsRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/convention/PublicMethodsBeforeNonPublicMethodsRule.groovy
@@ -25,8 +25,7 @@ import org.codenarc.util.WildcardPattern
  * <p/>
  * The <code>ignoreMethodNames</code> property optionally specifies one or more (comma-separated) non-public method
  * names that should be ignored (i.e., that should not cause a rule violation). The name(s) may optionally include
- * wildcard characters ('*' or '?'). A rule violation is still triggered if an ignored non-public method appears after
- * the first public method. In other words, all ignored non-public methods must appear above all public methods).
+ * wildcard characters ('*' or '?').
  *
  * @author Chris Mair
  * @author Peter Thomas
@@ -42,20 +41,18 @@ class PublicMethodsBeforeNonPublicMethodsRule extends AbstractAstVisitorRule {
 class PublicMethodsBeforeNonPublicMethodsAstVisitor extends AbstractAstVisitor {
 
     private boolean hasDeclaredNonPublicMethod = false
-    private boolean hasDeclaredPublicMethod = false
 
     @Override
     protected void visitMethodComplete(MethodNode node) {
-        if (node.public) {
-            hasDeclaredPublicMethod = true
-            if (hasDeclaredNonPublicMethod) {
-                addViolation(node, "The public method $node.name in class $currentClassName is declared after a non-public method")
+        boolean isIgnoredMethod = new WildcardPattern(rule.ignoreMethodNames, false).matches(node.name)
+        if (!isIgnoredMethod) {
+            if (node.public) {
+                if (hasDeclaredNonPublicMethod) {
+                    addViolation(node, "The public method $node.name in class $currentClassName is declared after a non-public method")
+                }
             }
-        }
-        else {
-            boolean isNameIgnored = new WildcardPattern(rule.ignoreMethodNames, false).matches(node.name)
-            if (!node.synthetic) {
-                if (!isNameIgnored || hasDeclaredPublicMethod) {
+            else {
+                if (!node.synthetic) {
                     hasDeclaredNonPublicMethod = true
                 }
             }

--- a/src/test/groovy/org/codenarc/rule/convention/PublicMethodsBeforeNonPublicMethodsRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/PublicMethodsBeforeNonPublicMethodsRuleTest.groovy
@@ -156,7 +156,7 @@ class PublicMethodsBeforeNonPublicMethodsRuleTest extends AbstractRuleTestCase<P
     }
 
     @Test
-    void test_PrivateMethodBetweenPublicMethods_IgnoreMatched_Violations() {
+    void test_PrivateMethodBetweenPublicMethods_IgnoreMatched_NoViolations() {
         final SOURCE = '''
             class MyClass {
                 static final String staticMethod1() { }
@@ -167,8 +167,7 @@ class PublicMethodsBeforeNonPublicMethodsRuleTest extends AbstractRuleTestCase<P
             }
         '''
         rule.ignoreMethodNames = 'getSomething'
-        assertViolations(SOURCE,
-            [line:7, source:'public String method2() { }', message:'public method method2 in class MyClass is declared after a non-public method'])
+        assertNoViolations(SOURCE)
     }
 
     @Test

--- a/src/test/groovy/org/codenarc/rule/convention/StaticMethodsBeforeInstanceMethodsRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/StaticMethodsBeforeInstanceMethodsRuleTest.groovy
@@ -246,7 +246,7 @@ class StaticMethodsBeforeInstanceMethodsRuleTest extends AbstractRuleTestCase<St
     }
 
     @Test
-    void test_InstanceMethodsBetweenStaticMethods_IgnoreMatched_Violations() {
+    void test_InstanceMethodsBetweenStaticMethods_IgnoreMatched_NoViolations() {
         final SOURCE = '''
             class MyClass {
                 // Getters and Setters
@@ -274,8 +274,7 @@ class StaticMethodsBeforeInstanceMethodsRuleTest extends AbstractRuleTestCase<St
             }
         '''
         rule.ignoreMethodNames = 'get*,set*'
-        assertViolations(SOURCE,
-            [line:13, source:'static final String staticMethod2(int id) { }', message:'public static method staticMethod2 in class MyClass is declared after a public instance method'])
+        assertNoViolations(SOURCE)
     }
 
     @Override


### PR DESCRIPTION
Added `ignoreMethodNames` option to `PublicMethodsBeforeNonPublicMethodsRule` and `StaticMethodsBeforeInstanceMethodsRule`. Added new tests and updated `codenarc-rules-convention.md` documentation. See [issue #790](https://github.com/CodeNarc/CodeNarc/issues/790) for context and rationale.