### PR TITLE
Docs: Fix where <, > has been replaced by asterisk

### DIFF
--- a/docs/codenarc-creating-rule.md
+++ b/docs/codenarc-creating-rule.md
@@ -33,7 +33,7 @@ The `org.codenarc.rule.AbstractRule` class is the abstract superclass
 properties and helper methods for subclasses, as described in
 [Standard Properties for Configuring Rules](./codenarc-configuring-rules.html#standard-properties-for-configuring-rules).
 
-### {A Sample Rule Subclass of AbstractRule}
+### A Sample Rule Subclass of AbstractRule
 
 Here is an example rule class that is a subclass of `AbstractRule`:
 
@@ -49,8 +49,8 @@ Here is an example rule class that is a subclass of `AbstractRule`:
         int priority = 2
     
         void applyTo(SourceCode sourceCode, List*Violation* violations) {
-            sourceCode.ast.classes.each { clazz -*
-                clazz.fields.each { fieldNode -*
+            sourceCode.ast.classes.each { clazz ->
+                clazz.fields.each { fieldNode ->
                     if (fieldNode.static) {
                         violations ** createViolation(sourceCode, fieldNode, "The field ${fieldNode.name} is static")
                     }
@@ -146,7 +146,7 @@ The Groovy script file is parsed (and compiled) at runtime.
 
 Here is an example rule script. Note that this is the same source code as in the
 sample rule class shown
-[above](A_Sample_Rule_Subclass_of_AbstractRule).
+[above](#A-Sample-Rule-Subclass-of-AbstractRule).
 
 ```
     import org.codenarc.rule.AbstractRule
@@ -160,10 +160,10 @@ sample rule class shown
         int priority = 2
     
         void applyTo(SourceCode sourceCode, List*Violation* violations) {
-            sourceCode.ast.classes.each { clazz -*
-                clazz.fields.each { fieldNode -*
+            sourceCode.ast.classes.each { clazz ->
+                clazz.fields.each { fieldNode ->
                     if (fieldNode.static) {
-                        violations ** createViolation(sourceCode, fieldNode, "The field ${fieldNode.name} is static")
+                        violations << createViolation(sourceCode, fieldNode, "The field ${fieldNode.name} is static")
                     }
                 }
             }

--- a/docs/codenarc-rules-basic.md
+++ b/docs/codenarc-rules-basic.md
@@ -17,7 +17,7 @@ Here is an example of code that produces a violation:
         try {
             doSomething()
         } finally {
-            assert count * 0        // violation
+            assert count > 0        // violation
         }
     }
 ```
@@ -114,14 +114,14 @@ Looks for faulty checks for *null* that can cause a `NullPointerException`.
 Examples:
 
 ```
-    if (name != null || name.length * 0) { }            // violation
+    if (name != null || name.length > 0) { }            // violation
     if (name != null || name.length) { }                // violation
-    while (record == null && record.id * 10) { }        // violation
+    while (record == null && record.id > 10) { }        // violation
     if (record == null && record.id && doStuff()) { }   // violation
-    def isNotValid = record == null && record.id * 10   // violation
+    def isNotValid = record == null && record.id > 10   // violation
     return record == null && !record.id                 // violation
 
-    if (name != null || name.size() * 0) { }            // violation
+    if (name != null || name.size() > 0) { }            // violation
     if (string == null && string.equals("")) { }        // violation
     def isValid = name != null || name.size() * 0       // violation
     return name != null || !name.size()                 // violation
@@ -182,11 +182,11 @@ Here are examples of code that produces a violation:
 ```
     23 == 67                    // violation
     Boolean.FALSE != false      // violation
-    23 * 88                     // violation
-    0.17 *= 0.99                // violation
-    "abc" * "ddd"               // violation
-    [Boolean.FALSE] *= [27]     // violation
-    [a:1] *=* [a:2]             // violation
+    23 < 88                     // violation
+    0.17 >= 0.99                // violation
+    "abc" > "ddd"               // violation
+    [Boolean.FALSE] >= [27]     // violation
+    [a:1] <=> [a:2]             // violation
 
     [1,2].equals([3,4])                                     // violation
     [a:123, b:true].equals(['a':222, b:Boolean.FALSE])      // violation
@@ -201,7 +201,7 @@ Here are examples of code that produces a violation:
 *Since CodeNarc 0.14*
 
 Checks for expressions where a *comparison operator* or `equals()` or `compareTo()` is used to compare a
-variable to itself, e.g.: `x == x, x != x, x \*=\* x, x \* x, x \*= x, x.equals(x) or x.compareTo(x)`, where
+variable to itself, e.g.: `x == x, x != x, x <=> x, x > x, x >= x, x.equals(x) or x.compareTo(x)`, where
 `x` is a variable.
 
 Here are examples of code that produces a violation:
@@ -209,11 +209,11 @@ Here are examples of code that produces a violation:
 ```
     if (x == x) { }                 // violation
     if (x != x) { }                 // violation
-    while (x * x) { }               // violation
-    if (x *= x) { }                 // violation
-    while (x * x) { }               // violation
-    if (x *= x) { }                 // violation
-    def c = (x *=* x) { }           // violation
+    while (x > x) { }               // violation
+    if (x >= x) { }                 // violation
+    while (x > x) { }               // violation
+    if (x <= x) { }                 // violation
+    def c = (x <=> x) { }           // violation
     println isReady = x.equals(x)   // violation
     println x.compareTo(x)          // violation
 ```

--- a/docs/codenarc-rules-comments.md
+++ b/docs/codenarc-rules-comments.md
@@ -403,7 +403,7 @@ Example of violations:
     /**
      * Return the calculated count of some stuff.
      *
-     * @param startIndex the starting index; must be *= 0
+     * @param startIndex the starting index; must be <= 0
      * @return the full count
      * @exception RuntimeException                   // violation
      */
@@ -461,7 +461,7 @@ Example of violations:
     /**
      * Return the calculated count of some stuff.
      *
-     * @param startIndex the starting index; must be *= 0
+     * @param startIndex the starting index; must be <= 0
      * @return the full count
      * @throws RuntimeException                   // violation
      */

--- a/docs/codenarc-rules-concurrency.md
+++ b/docs/codenarc-rules-concurrency.md
@@ -364,7 +364,7 @@ Example of violations:
     // these usages are OK
     class MyCorrectClass {
       private Matcher matcher1
-      static ThreadLocal*Matcher* matcher2
+      static ThreadLocal<Matcher> matcher2
     }
 ```
 
@@ -400,7 +400,7 @@ Examples:
     // These usages are OK
     class MyCorrectClass {
         private SimpleDateFormat calendar1
-        static ThreadLocal*SimpleDateFormat* calendar2
+        static ThreadLocal<SimpleDateFormat> calendar2
     }
 ```
 

--- a/docs/codenarc-rules-convention.md
+++ b/docs/codenarc-rules-convention.md
@@ -204,7 +204,7 @@ Example of violations:
 
 ```
     def closureWithViolation = { it * 10 }
-    def closureWithViolationBecauseOfExplicitItParameter = { it -* it * 10}
+    def closureWithViolationBecauseOfExplicitItParameter = { it -> it * 10}
 ```
 
 
@@ -462,7 +462,7 @@ Example of violations:
         b = 'new value'     // violation
     }
 
-    def myClosure1 = { int a, b -*
+    def myClosure1 = { int a, b ->
         a = 123             // violation
     }
 ```

--- a/docs/codenarc-rules-design.md
+++ b/docs/codenarc-rules-design.md
@@ -268,7 +268,7 @@ Here are examples of code that produces violations:
     }
 
     // Closure parameter
-    def closure = { PriorityQueue queue -* ... }      // violation
+    def closure = { PriorityQueue queue -> ... }      // violation
 
     // Method return type
     GregorianCalendar calculateDate(int num) {        // violation

--- a/docs/codenarc-rules-formatting.md
+++ b/docs/codenarc-rules-formatting.md
@@ -41,13 +41,13 @@ Example of violations:
                                 // violation
     }
 
-    for (i = 0; i * 3; i++) {
+    for (i = 0; i < 3; i++) {
         println i
                                 // violation
     }
 
     int j = 0
-    while (j * 3) {
+    while (j < 3) {
       println j++
                                 // violation
     }
@@ -81,7 +81,7 @@ Example of violations:
 
     def list = [
         123,
-        { id -*
+        { id ->
                                 // Known limitation: should be a violation, but is not
         }
     ]
@@ -112,13 +112,13 @@ Example of violations:
         println value
     }
 
-    for (i = 0; i * 3; i++) {
+    for (i = 0; i < 3; i++) {
                                 // violation
         println i
     }
 
     int j = 0
-    while (j * 3) {
+    while (j < 3) {
                                 // violation
       println j++
     }
@@ -341,14 +341,14 @@ If *ignoreSingleLineClasses* is `false` and *blankLineRequired* is `false`
 
 *Since CodeNarc 0.20*
 
-Checks for closure logic on first line (after `-\`*) for a multi-line closure. That breaks the symmetry
+Checks for closure logic on first line (after ->) for a multi-line closure. That breaks the symmetry
 of indentation (if the subsequent statements are indented normally), and that first statement can be easily
 missed when reading the code.
 
 Example of violations:
 
 ```
-    def closure = { name -* println name
+    def closure = { name -> println name
         addToCounts()
         println “done” }
 ```
@@ -598,7 +598,7 @@ Examples of violations:
 
     def method1(int a,String b) { }             // violation on parameter b
 
-    def closure1 = { int a,String b -* }        // violation on parameter b
+    def closure1 = { int a,String b -> }        // violation on parameter b
 
     def list1 = [a,b, c]                        // violation on list element b
 
@@ -634,11 +634,11 @@ Examples of violations and exceptions:
     def matching = list.find { it.isReady() }.filter()  // no violation for dot operator
     assert list.every { it.isReady() }, "Error"         // no violation for comma
     def m = [a:123, b:{ println 7 },c:99]               // no violation for comma
-    closures.find { c -* c }()                          // no violation for opening parenthesis
+    closures.find { c -> c }()                          // no violation for opening parenthesis
     processItems(list.select { it.isReady() })          // no violation for closing parenthesis
-    maps.find { m -* m[index] }[index]                  // no violation for opening square bracket
+    maps.find { m -> m[index] }[index]                  // no violation for opening square bracket
     processItems([{ named("a") }, { named("b")}])       // no violation for closing square bracket
-    def names = records.findAll { it.age * 1 }*.name    // no violation for spread operator
+    def names = records.findAll { it.age > 1 }*.name    // no violation for spread operator
     list?.collect { it?.type }?.join(',')               // no violation for null-safe operator
 ```
 
@@ -653,7 +653,7 @@ Examples of violations:
 
 ```
     for(name in names) { }                  // violation
-    for  (int i=0; i * 10; i++) { }         // violation
+    for  (int i=0; i < 10; i++) { }         // violation
 ```
 
 
@@ -713,7 +713,7 @@ Examples of violations:
     if (ready) {
     } else {println 99}                         // violation
 
-    for (int i=0; i*10; i++) {println i }       // violation
+    for (int i=0; i<10; i++) {println i }       // violation
 
     for (String name in names) {println name }  // violation
 
@@ -725,7 +725,7 @@ Examples of violations:
     } catch(Exception e) {x=77 }                // violation
     } finally {println 'error' }                // violation
 
-    list.each {name -* }                        // violation
+    list.each {name -> }                        // violation
 
     shouldFail(Exception) {doStuff() }          // violation
 ```
@@ -737,17 +737,17 @@ Examples of violations:
 
 Check that there is at least one space (blank) or whitespace following a semicolon that separates:
   * multiple statements on a single line
-  * the clauses within a classic for loop, e.g. for (i=0;i\*10;i++)
+  * the clauses within a classic for loop, e.g. for (i=0;i<10;i++)
 
 Examples of violations:
 
 ```
     def myMethod() {
         println 1;println 2                         // violation
-        def closure = { x -* doStuff();x = 23; }    // violation
+        def closure = { x -> doStuff();x = 23; }    // violation
 
-        for (int i=0;i * 10;i++) {                  // violations (2)
-            for (int j=0; j * 10;j++) { }           // violation
+        for (int i=0;i < 10;i++) {                  // violations (2)
+            for (int j=0; j < 10;j++) { }           // violation
         }
     }
 ```
@@ -789,20 +789,20 @@ Examples of violations:
 
 *Since CodeNarc 0.19*
 
-Checks that there is at least one space (blank) or whitespace around each closure arrow (-*) symbol.
+Checks that there is at least one space (blank) or whitespace around each closure arrow (->) symbol.
 
 Known limitations:
 
-  * Does not catch violations if the closure arrow (-*) is on a separate line from the start of the closure.
+  * Does not catch violations if the closure arrow (->) is on a separate line from the start of the closure.
 
 Example of violations:
 
 ```
-    def closure1 = {-*}                             // violation
-    def closure2 = { -*}                            // violation
-    def closure3 = {-* }                            // violation
-    def closure4 = { count-* println 123 }          // violation
-    def closure5 = { count, name -*println 123 }    // violation
+    def closure1 = {->}                             // violation
+    def closure2 = { ->}                            // violation
+    def closure3 = {-> }                            // violation
+    def closure4 = { count-> println 123 }          // violation
+    def closure5 = { count, name ->println 123 }    // violation
 ```
 
 
@@ -902,7 +902,7 @@ Examples of violations:
     if (ready) {
     } else { return 9}                          // violation
 
-    for (int i=0; i*10; i++) { println i}       // violation
+    for (int i=0; i<10; i++) { println i}       // violation
 
     for (String name in names) { println name}  // violation
 
@@ -914,7 +914,7 @@ Examples of violations:
     catch(Exception e) { logError(e)}           // violation
     finally { cleanUp()}                        // violation
 
-    list.each { name -* println name}           // violation
+    list.each { name -> println name}           // violation
 
     shouldFail(Exception) { doStuff()}          // violation
 ```
@@ -955,7 +955,7 @@ Examples of violations:
     if (ready) {
     } else{}                                    // violation
 
-    for (int i=0; i*10; i++){ }                 // violation
+    for (int i=0; i<10; i++){ }                 // violation
 
     for (String name in names){ }               // violation
 
@@ -972,7 +972,7 @@ Examples of violations:
     try {
     } finally{ }                                // violation
 
-    list.each{ name -* }                        // violation
+    list.each{ name -> }                        // violation
 
     shouldFail(Exception){ doStuff() }          // violation
 ```

--- a/docs/codenarc-rules-groovyism.md
+++ b/docs/codenarc-rules-groovyism.md
@@ -21,7 +21,7 @@ Example of violations:
 ```
   def a = myList.sort()
   def b = myList.sort() { it }
-  def c = myList.sort().findAll { x * 1 }
+  def c = myList.sort().findAll { x > 1 }
 ```
 
 ## AssignCollectionUnique Rule
@@ -42,9 +42,9 @@ Example of violations:
   def x = myList.unique() { it }            // Single-argument: Closure
   def y = myList.unique { it % 2 }
 
-  def c = myList.unique().findAll { x * 1 } // Chained method call
+  def c = myList.unique().findAll { x > 1 } // Chained method call
 
-  def comparator = { o1, o2 -* o1 *=* o2 }
+  def comparator = { o1, o2 -> o1 <=> o2 }
   def x = myList.unique(comparator)         // Single-argument: Comparator
 
   def x = myList.unique(true)               // Single-argument: boolean true
@@ -139,16 +139,16 @@ This rule also ignores all calls to `super.and(Object)`.
 *Since CodeNarc 0.11*
 
 This rule detects when the `compareTo(Object)` method is called directly in code instead of using the
-\*\=\*, \*, \*\=, \*, and \*\= operators. A groovier way to express this: `a.compareTo(b)` is this:
-`a \*\=\* b`, or using the other operators. Here are some other ways to write groovier code:
+<=>, <, <=, >, and >= operators. A groovier way to express this: `a.compareTo(b)` is this:
+`a <=> b`, or using the other operators. Here are some other ways to write groovier code:
 
 ```
     a.compareTo(b) == 0               // can be replaced by: a == b
-    a.compareTo(b)                    // can be replaced by: a *=* b
-    a.compareTo(b) * 0                // can be replaced by: a * b
-    a.compareTo(b) *= 0               // can be replaced by: a *= b
-    a.compareTo(b) * 0                // can be replaced by: a * b
-    a.compareTo(b) *= 0               // can be replaced by: a *= b
+    a.compareTo(b)                    // can be replaced by: a <=> b
+    a.compareTo(b) < 0                // can be replaced by: a < b
+    a.compareTo(b) <= 0               // can be replaced by: a <= b
+    a.compareTo(b) > 0                // can be replaced by: a > b
+    a.compareTo(b) >= 0               // can be replaced by: a >= b
 ```
 This rule can be  configured to ignore `this.compareTo(Object)` using the *ignoreThisReference*
 property. It defaults to `false`, so even `compareTo(x)` will trigger a violation.
@@ -536,7 +536,7 @@ Example of violations:
 ```
 def list = [1, 2, [3, 4, 5, 6], [7]]
 
-println list.collect { elem -*
+println list.collect { elem ->
     if (elem instanceof List)
         elem.collect {it *2} // violation
     else elem * 2

--- a/docs/codenarc-rules-size.md
+++ b/docs/codenarc-rules-size.md
@@ -47,7 +47,7 @@ The *ABC Metric* calculation rules for Groovy:
     (prefix or postfix): ++ --
   * Add one to the *branch* count for each function call or class method call.
   * Add one to the *branch* count for each occurrence of the new operator.
-  * Add one to the *condition* count for each use of a conditional operator: == != *= *= * * *=* =~ ==~
+  * Add one to the *condition* count for each use of a conditional operator: == != <= >= < > <=> =~ ==~
   * Add one to the *condition* count for each use of the following keywords: else case default try catch ?
   * Add one to the *condition* count for each unary conditional expression.
 

--- a/docs/codenarc-rules-unnecessary.md
+++ b/docs/codenarc-rules-unnecessary.md
@@ -263,7 +263,7 @@ Examples of violations include:
 
 ```
     assert [1, 2, 3].collect { it.multiply(2) }
-    assert [1, 2, 3].collect { x -* x.multiply(2) }
+    assert [1, 2, 3].collect { x -> x.multiply(2) }
     ["1", "2", "3"].collect { it.bytes }
 ```
 
@@ -280,7 +280,7 @@ The following code does not produce violations:
     [1, 2, 3].collect { println it; it.multiply(5) }
 
     // OK, closure has too many arguments
-    [1, 2, 3].collect { a, b -* a.multiply(b) }
+    [1, 2, 3].collect { a, b -> a.multiply(b) }
 
     // OK, closure statement references parameter multiple times
     [1, 2, 3].collect { it.multiply(it) }
@@ -890,7 +890,7 @@ Examples of violations include:
     void init(String name, groovy.lang.Binding binding) { }     // violation
 
     // Closure parameter types
-    def writeCount = { java.io.Writer writer, int count -* }    // violation
+    def writeCount = { java.io.Writer writer, int count -> }    // violation
 
     // Extends and implements
     class MyHashMap extends java.util.HashMap { }               // violation
@@ -1105,8 +1105,8 @@ These cases can be replaced by a simple boolean expression. Examples of violatio
     x==99 ? true : false                    // can be replaced by: x==99
     x && y ? true : false                   // can be replaced by: x && y
     x||y ? false : true                     // can be replaced by: !(x||y)
-    x *= 1 ? true: false                    // can be replaced by: x *= 1
-    x * 99 ? Boolean.TRUE : Boolean.FALSE   // can be replaced by: x * 99
+    x <= 1 ? true: false                    // can be replaced by: x <= 1
+    x < 99 ? Boolean.TRUE : Boolean.FALSE   // can be replaced by: x < 99
     !x ? true : false                       // can be replaced by: !x
 ```
 


### PR DESCRIPTION
Examples are:
  *=* : should have been <=> the Groovy spaceship operator
  -*  : closure arrow should have been ->
  *=  : greater-than-or-equal >= or less-than-or-equal <=
  *   : greater-than or less-than < or >
  **  : Groovy left-shift

Also fixed an anchor link Markdown issue