### PR TITLE
Additional `PropertiesFileRuleSetConfigurer.configure(..)` log aiding debugging.

### DIFF
--- a/src/main/groovy/org/codenarc/ruleset/PropertiesFileRuleSetConfigurer.groovy
+++ b/src/main/groovy/org/codenarc/ruleset/PropertiesFileRuleSetConfigurer.groovy
@@ -76,7 +76,11 @@ class PropertiesFileRuleSetConfigurer implements RuleSetConfigurer {
             }
         }
         catch(IOException e) {
-            LOG.info("RuleSet configuration properties file [$actualPropertiesFilename] not found.")
+            if (LOG.debugEnabled) {
+                LOG.debug("RuleSet configuration actualPropertiesFilename [$actualPropertiesFilename] not found (propertiesFilename [$propertiesFilename]).")
+            } else {
+                LOG.info("RuleSet configuration properties file [$actualPropertiesFilename] not found.")
+            }
         }
     }
 

--- a/src/main/groovy/org/codenarc/ruleset/PropertiesFileRuleSetConfigurer.groovy
+++ b/src/main/groovy/org/codenarc/ruleset/PropertiesFileRuleSetConfigurer.groovy
@@ -76,11 +76,7 @@ class PropertiesFileRuleSetConfigurer implements RuleSetConfigurer {
             }
         }
         catch(IOException e) {
-            if (LOG.debugEnabled) {
-                LOG.debug("RuleSet configuration actualPropertiesFilename [$actualPropertiesFilename] not found (propertiesFilename [$propertiesFilename]).")
-            } else {
-                LOG.info("RuleSet configuration properties file [$actualPropertiesFilename] not found.")
-            }
+            LOG.info("RuleSet configuration properties file [$actualPropertiesFilename] not found${propertiesFilename ? "; propertiesFilename=$propertiesFilename" : ''}.")
         }
     }
 


### PR DESCRIPTION
This (or similar) debug logging would've been very helpful in teasing out the root cause of https://github.com/gradle/gradle/issues/34239 , when attempting to reason about state versus output for the `getActualPropertiesFile(..)` branches 🤓 

