### PR TITLE
New rule OneTopLevelClass

### DIFF
--- a/docs/codenarc-rules-convention.md
+++ b/docs/codenarc-rules-convention.md
@@ -447,6 +447,17 @@ somewhere above the violation will disable this rule. See
 [Disabling Rules From Comments](./codenarc-configuring-rules.html#disabling-rules-from-comments).
 
 
+## OneTopLevelClass Rule
+
+*Since CodeNarc 4.0.0*
+
+Checks that each source file contains only one top-level class / enum / interface.
+
+NOTE: This is a file-based rule, rather than an AST-based rule, so the *applyToClassNames* and
+*doNotApplyToClassNames* rule configuration properties are not available. See
+[Standard Properties for Configuring Rules](./codenarc-configuring-rules.html#standard-properties-for-configuring-rules).
+
+
 ## ParameterReassignment Rule
 
 *Since CodeNarc 0.17*

--- a/src/main/groovy/org/codenarc/rule/convention/OneTopLevelClassRule.groovy
+++ b/src/main/groovy/org/codenarc/rule/convention/OneTopLevelClassRule.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codenarc.rule.convention
+
+import org.codehaus.groovy.ast.ClassNode
+import org.codenarc.rule.AbstractRule
+import org.codenarc.rule.Violation
+import org.codenarc.source.SourceCode
+
+/**
+ * Checks that each source file contains only one top-level class / enum / interface.
+ *
+ * @author Robert Insley
+ */
+class OneTopLevelClassRule extends AbstractRule {
+
+    String name = 'OneTopLevelClass'
+    int priority = 3
+
+    @Override
+    void applyTo(SourceCode sourceCode, List<Violation> violations) {
+        if (!sourceCode.name) {
+            return
+        }
+
+        List<ClassNode> classes = sourceCode?.ast?.classes
+        if (classes.any { it.isScript() }) {
+            return
+        }
+
+        List<ClassNode> topLevelClasses = classes?.findAll { !it.outerClass }
+        if (topLevelClasses?.size() > 1) {
+            topLevelClasses.eachWithIndex { ClassNode topLevelClass, Integer index ->
+                if (index > 0) {
+                    violations << createViolation(sourceCode, topLevelClass,
+                        "`${sourceCode.name}` contains more than one top-level class / enum / interface. " +
+                        "Move `${topLevelClass.nameWithoutPackage}` to its own file.")
+                }
+            }
+        }
+    }
+
+    String classNodeType(ClassNode classNode) {
+        return classNode.isInterface() ? 'Interface' :
+               classNode.isEnum() ? 'Enum' :
+               'Class'
+    }
+}

--- a/src/main/resources/codenarc-base-messages.properties
+++ b/src/main/resources/codenarc-base-messages.properties
@@ -1129,6 +1129,9 @@ StatelessSingleton.description.html=There is no point in creating a stateless Si
 PrivateFieldCouldBeFinal.description=Checks for private fields that are only set within a constructor or field initializer. Such fields can safely be made final.
 PrivateFieldCouldBeFinal.description.html=Checks for <em>private</em> fields that are only set within a constructor or field initializer. Such fields can safely be made <em>final</em>.
 
+OneTopLevelClass.description=Checks that each source file contains only one top-level class / enum / interface.
+OneTopLevelClass.description.html=Checks that each source file contains only one top-level class / enum / interface.
+
 ParameterReassignment.description=Checks for a method or closure parameter being reassigned to a new value within the body of the method/closure, which is a confusing and questionable practice. Use a temporary variable instead.
 ParameterReassignment.description.html=Checks for a method or closure parameter being reassigned to a new value within the body of the method/closure, which is a confusing and questionable practice. Use a temporary variable instead.
 

--- a/src/main/resources/rulesets/convention.xml
+++ b/src/main/resources/rulesets/convention.xml
@@ -27,6 +27,7 @@
     <rule class='org.codenarc.rule.convention.NoFloatRule'/>
     <rule class='org.codenarc.rule.convention.NoJavaUtilDateRule'/>
     <rule class='org.codenarc.rule.convention.NoTabCharacterRule'/>
+    <rule class='org.codenarc.rule.convention.OneTopLevelClassRule'/>
     <rule class='org.codenarc.rule.convention.ParameterReassignmentRule'/>
     <rule class='org.codenarc.rule.convention.PublicMethodsBeforeNonPublicMethodsRule'/>
     <rule class='org.codenarc.rule.convention.StaticFieldsBeforeInstanceFieldsRule'/>

--- a/src/test/groovy/org/codenarc/rule/convention/OneTopLevelClassRuleTest.groovy
+++ b/src/test/groovy/org/codenarc/rule/convention/OneTopLevelClassRuleTest.groovy
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codenarc.rule.convention
+
+import org.codenarc.rule.AbstractRuleTestCase
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for OneTopLevelClassRule
+ *
+ * @author Robert Insley
+ */
+class OneTopLevelClassRuleTest extends AbstractRuleTestCase<OneTopLevelClassRule> {
+
+    @BeforeEach
+    void setup() {
+        sourceCodeName = 'MyClass.groovy'
+    }
+
+    @Test
+    void testRuleProperties() {
+        assert rule.priority == 3
+        assert rule.name == 'OneTopLevelClass'
+    }
+
+    @Test
+    void testNoViolationsOnClass() {
+        final SOURCE = '''
+            class MyClass {
+                int myInt
+            }
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testNoViolationsOnEnum() {
+        final SOURCE = '''
+            enum MyEnum {
+                OPTION_ONE, OPTION_TWO
+            }
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testNoViolationsOnInterface() {
+        final SOURCE = '''
+            interface MyInterface {}
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testNoViolationsOnInnerTypes() {
+        final SOURCE = '''
+            class MyClass {
+                class InnerClass {}
+                enum InnerEnum {
+                    OPTION_ONE, OPTION_TWO
+                }
+                interface InnerInterface {}
+            }
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testTwoClasses_Violation() {
+        final SOURCE = '''
+            class FirstClass {}
+            class SecondClass {}
+        '''
+        assertSingleViolation(SOURCE, 3, 'class SecondClass {}',
+            '`MyClass.groovy` contains more than one top-level class / enum / interface. Move `SecondClass` to its own file.')
+    }
+
+    @Test
+    void testThreeClasses_MultipleViolations() {
+        final SOURCE = '''
+            class FirstClass {}
+            class SecondClass {}
+            class ThirdClass {}
+        '''
+        assertViolations(SOURCE,
+            [line: 3, source: 'class SecondClass {}',
+             message: '`MyClass.groovy` contains more than one top-level class / enum / interface. Move `SecondClass` to its own file.'],
+            [line: 4, source: 'class ThirdClass {}',
+             message: '`MyClass.groovy` contains more than one top-level class / enum / interface. Move `ThirdClass` to its own file.'])
+    }
+
+    @Test
+    void testTwoEnums_Violation() {
+        final SOURCE = '''
+            enum EnumOne {
+                OPTION_ONE, OPTION_TWO
+            }
+            enum EnumTwo {
+                OPTION_A, OPTION_B
+            }
+        '''
+        assertSingleViolation(SOURCE, 5, 'enum EnumTwo {',
+            '`MyClass.groovy` contains more than one top-level class / enum / interface. Move `EnumTwo` to its own file.')
+    }
+
+    @Test
+    void testTwoInterfaces_Violation() {
+        final SOURCE = '''
+            interface InterfaceOne {}
+            interface InterfaceTwo {}
+        '''
+        assertSingleViolation(SOURCE, 3, 'interface InterfaceTwo {}',
+            '`MyClass.groovy` contains more than one top-level class / enum / interface. Move `InterfaceTwo` to its own file.')
+    }
+
+    @Test
+    void testThreeTypes_MultipleViolations() {
+        final SOURCE = '''
+            class FirstClass {}
+            enum MyEnum {
+                OPTION_ONE, OPTION_TWO
+            }
+            interface MyInterface {}
+        '''
+        assertViolations(SOURCE,
+            [line: 3, source: 'enum MyEnum {',
+             message: '`MyClass.groovy` contains more than one top-level class / enum / interface. Move `MyEnum` to its own file.'],
+            [line: 6, source: 'interface MyInterface {}',
+             message: '`MyClass.groovy` contains more than one top-level class / enum / interface. Move `MyInterface` to its own file.'])
+    }
+
+    @Test
+    void testNoViolationsOnScript() {
+        final SOURCE = '''
+            println 'Hello'
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testNoViolationsOnScriptWithClass() {
+        final SOURCE = '''
+            println 'Hello'
+            class MyClass {}
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testNoViolationsOnScriptWithMultipleClasses() {
+        final SOURCE = '''
+            println 'Hello'
+            class FirstClass {}
+            class SecondClass {}
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testNoViolationsOnScriptWithMultipleTypes() {
+        final SOURCE = '''
+            println 'Hello'
+            enum MyEnum {
+                OPTION_ONE, OPTION_TWO
+            }
+            interface MyInterface {}
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Test
+    void testNoViolationsOnEmptySource() {
+        final SOURCE = '''
+        '''
+        assertNoViolations(SOURCE)
+    }
+
+    @Override
+    protected OneTopLevelClassRule createRule() {
+        new OneTopLevelClassRule()
+    }
+}

--- a/src/test/resources/RunCodeNarcAgainstProjectSourceCode.ruleset
+++ b/src/test/resources/RunCodeNarcAgainstProjectSourceCode.ruleset
@@ -21,6 +21,7 @@ ruleset {
         exclude 'VariableTypeRequired'
         exclude 'ImplicitClosureParameter'
         exclude 'ImplicitReturnStatement'
+		exclude 'OneTopLevelClass'
         FieldTypeRequired(doNotApplyToFilesMatching:TEST_FILES)
     }
 


### PR DESCRIPTION
This adds a new rule OneTopLevelClass to require exactly one top-level class/enum/interface per file. The rule is patterned off of and similar to ClassNameSameAsFilename but added to the convention ruleset instead, as this is more of a Java/Groovy convention than a naming issue. Classes inside scripts or other classes are not considered violations. Similar to some other convention rules, it has to be excluded from the RunCodeNarcAgainstProjectSourceCode.ruleset.